### PR TITLE
CardDrawer Assets Unification

### DIFF
--- a/Example_MeliCardDrawer/Podfile
+++ b/Example_MeliCardDrawer/Podfile
@@ -1,6 +1,6 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
-platform :ios, '9.0'
+platform :ios, '10.0'
 use_frameworks!
 
 target 'Example_MeliCardDrawer' do

--- a/Source/Classes/View/CardView/Front/FrontView.swift
+++ b/Source/Classes/View/CardView/Front/FrontView.swift
@@ -3,8 +3,6 @@ import UIKit
 class FrontView: CardView {
     @IBOutlet weak var expirationDate: CardLabel!
     @IBOutlet weak var name: CardLabel!
-    @IBOutlet weak var logo: UIImageView!
-    @IBOutlet weak var bank: UIImageView!
     @IBOutlet weak var remotePaymentMethodImage: UIImageView!
     @IBOutlet weak var remoteBankImage: UIImageView!
     @IBOutlet weak var number: CardLabel!
@@ -16,10 +14,10 @@ class FrontView: CardView {
         
         setupSecurityCode(cardUI)
         if cardUI.set(logo:) != nil {
-            setupCardLogo(in: logo)
+            setupCardLogo(in: remotePaymentMethodImage)
         }
         if cardUI.set(bank:) != nil {
-            setupBankImage(in: bank)
+            setupBankImage(in: remoteBankImage)
         }
         setupRemoteOrLocalImages(cardUI)
         
@@ -73,7 +71,7 @@ extension FrontView {
         if !(cardUI is CustomCardDrawerUI) {
             Animator.overlay(on: self,
                              cardUI: cardUI,
-                             views: [bank, expirationDate, logo, name, number, securityCode],
+                             views: [remoteBankImage, expirationDate, remotePaymentMethodImage, name, number, securityCode],
                              complete: {[weak self] in
                                 self?.setupUI(cardUI)
             })
@@ -90,7 +88,6 @@ extension FrontView {
     }
 
     private func setPaymentMethodImage(_ cardUI: CardUI) {
-        logo.image = nil
         remotePaymentMethodImage.image = nil
         if let imageUrl = cardUI.cardLogoImageUrl as? String, !imageUrl.isEmpty {
             UIImageView().getRemoteImage(imageUrl: imageUrl) { image in
@@ -100,12 +97,11 @@ extension FrontView {
                 }
             }
         } else if let image = cardUI.cardLogoImage as? UIImage {
-            setImage(image, inImageView: logo)
+            setImage(image, inImageView: remotePaymentMethodImage, scaleHeight: true)
         }
     }
 
     private func setBankImage(_ cardUI: CardUI) {
-        bank.image = nil
         remoteBankImage.image = nil
         if let imageUrl = cardUI.bankImageUrl as? String, !imageUrl.isEmpty {
             UIImageView().getRemoteImage(imageUrl: imageUrl) { remoteBankImage in
@@ -115,10 +111,8 @@ extension FrontView {
                 }
             }
         } else if let image = cardUI.bankImage as? UIImage {
-            setImage(image, inImageView: bank)
+            setImage(image, inImageView: remoteBankImage, scaleHeight: true)
         }
-        
-        setupBankImage(in: bank)
     }
 
     private func setImage(_ tImage: UIImage, inImageView: UIImageView, scaleHeight: Bool = false) {

--- a/Source/Classes/View/CardView/Front/FrontView.swift
+++ b/Source/Classes/View/CardView/Front/FrontView.swift
@@ -3,8 +3,8 @@ import UIKit
 class FrontView: CardView {
     @IBOutlet weak var expirationDate: CardLabel!
     @IBOutlet weak var name: CardLabel!
-    @IBOutlet weak var remotePaymentMethodImage: UIImageView!
-    @IBOutlet weak var remoteBankImage: UIImageView!
+    @IBOutlet weak var paymentMethodImage: UIImageView!
+    @IBOutlet weak var bankImage: UIImageView!
     @IBOutlet weak var number: CardLabel!
     @IBOutlet weak var securityCodeCircle: CircleView!
 
@@ -14,10 +14,10 @@ class FrontView: CardView {
         
         setupSecurityCode(cardUI)
         if cardUI.set(logo:) != nil {
-            setupCardLogo(in: remotePaymentMethodImage)
+            setupCardLogo(in: paymentMethodImage)
         }
         if cardUI.set(bank:) != nil {
-            setupBankImage(in: remoteBankImage)
+            setupBankImage(in: bankImage)
         }
         setupRemoteOrLocalImages(cardUI)
         
@@ -71,7 +71,7 @@ extension FrontView {
         if !(cardUI is CustomCardDrawerUI) {
             Animator.overlay(on: self,
                              cardUI: cardUI,
-                             views: [remoteBankImage, expirationDate, remotePaymentMethodImage, name, number, securityCode],
+                             views: [bankImage, expirationDate, paymentMethodImage, name, number, securityCode],
                              complete: {[weak self] in
                                 self?.setupUI(cardUI)
             })
@@ -88,38 +88,38 @@ extension FrontView {
     }
 
     private func setPaymentMethodImage(_ cardUI: CardUI) {
-        remotePaymentMethodImage.image = nil
+        paymentMethodImage.image = nil
         if let imageUrl = cardUI.cardLogoImageUrl as? String, !imageUrl.isEmpty {
             UIImageView().getRemoteImage(imageUrl: imageUrl) { image in
                 DispatchQueue.main.async { [weak self] in
                     guard let self = self else { return }
-                    self.setImage(image, inImageView: self.remotePaymentMethodImage, scaleHeight: true)
+                    self.setImage(image, inImageView: self.paymentMethodImage)
                 }
             }
         } else if let image = cardUI.cardLogoImage as? UIImage {
-            setImage(image, inImageView: remotePaymentMethodImage, scaleHeight: true)
+            setImage(image, inImageView: paymentMethodImage)
         }
     }
 
     private func setBankImage(_ cardUI: CardUI) {
-        remoteBankImage.image = nil
+        bankImage.image = nil
         if let imageUrl = cardUI.bankImageUrl as? String, !imageUrl.isEmpty {
             UIImageView().getRemoteImage(imageUrl: imageUrl) { remoteBankImage in
                 DispatchQueue.main.async { [weak self] in
                     guard let self = self else { return }
-                    self.setImage(remoteBankImage, inImageView: self.remoteBankImage, scaleHeight: true)
+                    self.setImage(remoteBankImage, inImageView: self.bankImage)
                 }
             }
         } else if let image = cardUI.bankImage as? UIImage {
-            setImage(image, inImageView: remoteBankImage, scaleHeight: true)
+            setImage(image, inImageView: bankImage)
         }
     }
 
-    private func setImage(_ tImage: UIImage, inImageView: UIImageView, scaleHeight: Bool = false) {
+    private func setImage(_ tImage: UIImage, inImageView: UIImageView) {
+        inImageView.image = UIImage.scale(image: tImage,
+                                          by: inImageView.bounds.size.height/tImage.size.height)
         if disabledMode {
             inImageView.image = tImage.imageGreyScale()
-        } else {
-            inImageView.image = scaleHeight ? UIImage.scale(image: tImage, by: inImageView.bounds.size.height/tImage.size.height) : tImage
         }
     }
 }

--- a/Source/Classes/View/CardView/Front/FrontView.xib
+++ b/Source/Classes/View/CardView/Front/FrontView.xib
@@ -38,10 +38,10 @@
                     <rect key="frame" x="0.0" y="0.0" width="256" height="158"/>
                 </imageView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eki-qS-IGB" userLabel="PaymentContainer">
-                    <rect key="frame" x="24" y="16" width="112" height="40"/>
+                    <rect key="frame" x="21" y="16" width="99" height="35"/>
                     <subviews>
                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="hVB-2M-iYt" userLabel="remotePaymentMethodImage" customClass="UIImageViewAligned" customModule="MLCardDrawer" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="5" width="112" height="30"/>
+                            <rect key="frame" x="0.0" y="2.5" width="99" height="30"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="30" id="3wp-Qm-Vp5"/>
                             </constraints>
@@ -50,44 +50,42 @@
                             </userDefinedRuntimeAttributes>
                         </imageView>
                     </subviews>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <color key="backgroundColor" systemColor="systemYellowColor" red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstItem="hVB-2M-iYt" firstAttribute="centerY" secondItem="eki-qS-IGB" secondAttribute="centerY" id="Id4-46-ZQG"/>
                         <constraint firstAttribute="trailing" secondItem="hVB-2M-iYt" secondAttribute="trailing" id="NVd-Vs-AgW"/>
                         <constraint firstItem="hVB-2M-iYt" firstAttribute="leading" secondItem="eki-qS-IGB" secondAttribute="leading" id="jbe-j2-z9d"/>
-                        <constraint firstAttribute="height" constant="40" id="nXL-am-y6R"/>
+                        <constraint firstAttribute="height" constant="35" id="nXL-am-y6R"/>
                     </constraints>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fle-ET-bnW" userLabel="IssuerContainer">
-                    <rect key="frame" x="124" y="12" width="108" height="44"/>
+                    <rect key="frame" x="136" y="16" width="99" height="35"/>
                     <subviews>
-                        <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="750" image="logo" translatesAutoresizingMaskIntoConstraints="NO" id="DT6-XG-kaD" userLabel="IssuerIcon">
-                            <rect key="frame" x="76" y="6" width="32" height="32"/>
+                        <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="iqG-Eo-eGS" userLabel="remoteBankImage" customClass="UIImageViewAligned" customModule="MLCardDrawer" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="2.5" width="99" height="30"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="30" id="ooY-WT-yGo"/>
+                            </constraints>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="boolean" keyPath="alignRight" value="YES"/>
+                            </userDefinedRuntimeAttributes>
                         </imageView>
                     </subviews>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <color key="backgroundColor" systemColor="systemTealColor" red="0.35294117650000001" green="0.7843137255" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
-                        <constraint firstItem="DT6-XG-kaD" firstAttribute="centerY" secondItem="Fle-ET-bnW" secondAttribute="centerY" id="BT5-rW-LgL"/>
-                        <constraint firstAttribute="width" constant="108" id="Rc4-oG-oEO"/>
-                        <constraint firstAttribute="height" constant="44" id="tVL-Wf-KZV"/>
-                        <constraint firstAttribute="trailing" secondItem="DT6-XG-kaD" secondAttribute="trailing" id="uUY-jM-4mL"/>
+                        <constraint firstItem="iqG-Eo-eGS" firstAttribute="centerY" secondItem="Fle-ET-bnW" secondAttribute="centerY" id="IpL-Hd-bBF"/>
+                        <constraint firstItem="iqG-Eo-eGS" firstAttribute="leading" secondItem="Fle-ET-bnW" secondAttribute="leading" id="LuD-zW-VGl"/>
+                        <constraint firstAttribute="trailing" secondItem="iqG-Eo-eGS" secondAttribute="trailing" id="PP4-An-lQe"/>
                     </constraints>
                 </view>
-                <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="iqG-Eo-eGS" userLabel="remoteBankImage">
-                    <rect key="frame" x="232" y="19" width="0.0" height="30"/>
-                    <constraints>
-                        <constraint firstAttribute="width" priority="250" id="Yok-kB-Xw6"/>
-                        <constraint firstAttribute="height" constant="30" id="ooY-WT-yGo"/>
-                    </constraints>
-                </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MM/AA" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AMu-xJ-OI6" customClass="CardLabel" customModule="MLCardDrawer" customModuleProvider="target">
-                    <rect key="frame" x="185" y="114.5" width="47" height="17"/>
+                    <rect key="frame" x="188" y="114.5" width="47" height="17"/>
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <view alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="89T-PX-cWX" userLabel="circleFronSecurityCodeView" customClass="CircleView" customModule="MLCardDrawer" customModuleProvider="target">
-                    <rect key="frame" x="203" y="46" width="39" height="39"/>
+                    <rect key="frame" x="206" y="46" width="39" height="39"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="39" id="35R-WB-d8w"/>
@@ -106,12 +104,12 @@
                     </userDefinedRuntimeAttributes>
                 </view>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="***" textAlignment="center" lineBreakMode="tailTruncation" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="K3c-vy-wcQ" userLabel="FrontSecurityCodeLabel" customClass="CardLabel" customModule="MLCardDrawer" customModuleProvider="target">
-                    <rect key="frame" x="215" y="58.5" width="17" height="14.5"/>
+                    <rect key="frame" x="218" y="58.5" width="17" height="14.5"/>
                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NOMBRE Y APELLIDO" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZMN-U6-Lcy" customClass="CardLabel" customModule="MLCardDrawer" customModuleProvider="target">
-                    <rect key="frame" x="24" y="112" width="166" height="22"/>
+                    <rect key="frame" x="21" y="112" width="166" height="22"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="166" id="FBH-we-hcG"/>
                     </constraints>
@@ -120,7 +118,7 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="**** **** **** ****" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="13" translatesAutoresizingMaskIntoConstraints="NO" id="EUo-1b-VQe" customClass="CardLabel" customModule="MLCardDrawer" customModuleProvider="target">
-                    <rect key="frame" x="24" y="82" width="208" height="18"/>
+                    <rect key="frame" x="21" y="82" width="214" height="18"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="18" id="cXL-fC-pUa"/>
                     </constraints>
@@ -129,7 +127,7 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="N94-Fg-ynK" userLabel="LimitView">
-                    <rect key="frame" x="120" y="31" width="16" height="10"/>
+                    <rect key="frame" x="120" y="28.5" width="16" height="10"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="16" id="Cin-WG-4v2"/>
@@ -141,14 +139,14 @@
             <constraints>
                 <constraint firstItem="OEt-3Q-8ri" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="0si-Gj-xOe"/>
                 <constraint firstItem="HLQ-m9-78F" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="1Vb-Vh-OMD"/>
-                <constraint firstItem="eki-qS-IGB" firstAttribute="trailing" secondItem="N94-Fg-ynK" secondAttribute="trailing" id="3Bk-h4-rS6"/>
+                <constraint firstItem="eki-qS-IGB" firstAttribute="trailing" secondItem="N94-Fg-ynK" secondAttribute="leading" id="3Bk-h4-rS6"/>
                 <constraint firstAttribute="trailing" secondItem="W2g-Ht-hY3" secondAttribute="trailing" id="42g-gv-JyA"/>
-                <constraint firstItem="ZMN-U6-Lcy" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="24" id="47K-ZK-WHj"/>
+                <constraint firstItem="ZMN-U6-Lcy" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="21" id="47K-ZK-WHj"/>
                 <constraint firstItem="EUo-1b-VQe" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" constant="12" id="5aG-Iu-7JU"/>
                 <constraint firstAttribute="bottom" secondItem="HLQ-m9-78F" secondAttribute="bottom" id="8Hh-Yk-8Vu"/>
-                <constraint firstItem="Fle-ET-bnW" firstAttribute="top" secondItem="eki-qS-IGB" secondAttribute="bottom" constant="-44" id="9Ct-vW-n6C"/>
+                <constraint firstItem="Fle-ET-bnW" firstAttribute="centerY" secondItem="eki-qS-IGB" secondAttribute="centerY" id="ABo-lq-EY8"/>
                 <constraint firstAttribute="bottom" secondItem="W2g-Ht-hY3" secondAttribute="bottom" id="DWY-GP-FQC"/>
-                <constraint firstItem="iqG-Eo-eGS" firstAttribute="centerY" secondItem="Fle-ET-bnW" secondAttribute="centerY" id="FWA-Zr-C3W"/>
+                <constraint firstItem="Fle-ET-bnW" firstAttribute="leading" secondItem="N94-Fg-ynK" secondAttribute="trailing" id="He0-Y4-rhP"/>
                 <constraint firstItem="eki-qS-IGB" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="16" id="IZx-jY-Fec"/>
                 <constraint firstItem="N94-Fg-ynK" firstAttribute="centerY" secondItem="eki-qS-IGB" secondAttribute="centerY" id="JAx-5z-yUI"/>
                 <constraint firstAttribute="bottom" secondItem="ZMN-U6-Lcy" secondAttribute="bottom" constant="24" id="JBg-7G-omn"/>
@@ -162,11 +160,10 @@
                 <constraint firstItem="AMu-xJ-OI6" firstAttribute="centerY" secondItem="ZMN-U6-Lcy" secondAttribute="centerY" id="YcG-Cp-uXh"/>
                 <constraint firstItem="Fle-ET-bnW" firstAttribute="trailing" secondItem="AMu-xJ-OI6" secondAttribute="trailing" id="ZmV-6D-57z"/>
                 <constraint firstItem="OEt-3Q-8ri" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="eq2-Nh-tjE"/>
-                <constraint firstItem="iqG-Eo-eGS" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="N94-Fg-ynK" secondAttribute="trailing" id="fb4-Mq-phu"/>
                 <constraint firstItem="EUo-1b-VQe" firstAttribute="leading" secondItem="ZMN-U6-Lcy" secondAttribute="leading" id="gPR-jP-sT0"/>
                 <constraint firstItem="K3c-vy-wcQ" firstAttribute="centerY" secondItem="89T-PX-cWX" secondAttribute="centerY" id="goL-C4-4Ge"/>
-                <constraint firstAttribute="trailing" secondItem="AMu-xJ-OI6" secondAttribute="trailing" constant="24" id="mQC-Xx-HlH"/>
-                <constraint firstItem="iqG-Eo-eGS" firstAttribute="trailing" secondItem="Fle-ET-bnW" secondAttribute="trailing" id="n6U-51-Iw9"/>
+                <constraint firstItem="Fle-ET-bnW" firstAttribute="height" secondItem="eki-qS-IGB" secondAttribute="height" id="l4O-bB-U3b"/>
+                <constraint firstAttribute="trailing" secondItem="AMu-xJ-OI6" secondAttribute="trailing" constant="21" id="mQC-Xx-HlH"/>
                 <constraint firstItem="W2g-Ht-hY3" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="nHh-K1-jH2"/>
                 <constraint firstAttribute="bottom" secondItem="OEt-3Q-8ri" secondAttribute="bottom" id="qUC-5Y-BgY"/>
                 <constraint firstItem="eki-qS-IGB" firstAttribute="leading" secondItem="ZMN-U6-Lcy" secondAttribute="leading" id="qwy-YV-L6X"/>
@@ -183,6 +180,5 @@
     </objects>
     <resources>
         <image name="Overlay" width="256" height="158"/>
-        <image name="logo" width="16" height="16"/>
     </resources>
 </document>

--- a/Source/Classes/View/CardView/Front/FrontView.xib
+++ b/Source/Classes/View/CardView/Front/FrontView.xib
@@ -10,13 +10,13 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="FrontView" customModule="MLCardDrawer" customModuleProvider="target">
             <connections>
                 <outlet property="animation" destination="OEt-3Q-8ri" id="0bW-HL-KCE"/>
+                <outlet property="bankImage" destination="iqG-Eo-eGS" id="OQn-yr-FpB"/>
                 <outlet property="expirationDate" destination="AMu-xJ-OI6" id="uGb-Mm-U1i"/>
                 <outlet property="gradient" destination="W2g-Ht-hY3" id="gsv-Yn-Xxg"/>
                 <outlet property="name" destination="ZMN-U6-Lcy" id="YHC-Uc-QhK"/>
                 <outlet property="number" destination="EUo-1b-VQe" id="db1-YE-CVB"/>
                 <outlet property="overlayImage" destination="HLQ-m9-78F" id="0tL-aV-K2z"/>
-                <outlet property="remoteBankImage" destination="iqG-Eo-eGS" id="OQn-yr-FpB"/>
-                <outlet property="remotePaymentMethodImage" destination="hVB-2M-iYt" id="Tr2-It-Ho8"/>
+                <outlet property="paymentMethodImage" destination="hVB-2M-iYt" id="Tr2-It-Ho8"/>
                 <outlet property="securityCode" destination="K3c-vy-wcQ" id="ghT-Qi-ZGO"/>
                 <outlet property="securityCodeCircle" destination="89T-PX-cWX" id="Edb-BS-E6z"/>
             </connections>
@@ -38,10 +38,10 @@
                     <rect key="frame" x="0.0" y="0.0" width="256" height="158"/>
                 </imageView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eki-qS-IGB" userLabel="PaymentContainer">
-                    <rect key="frame" x="21" y="16" width="99" height="35"/>
+                    <rect key="frame" x="24" y="16" width="96" height="40"/>
                     <subviews>
                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="hVB-2M-iYt" userLabel="remotePaymentMethodImage" customClass="UIImageViewAligned" customModule="MLCardDrawer" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="2.5" width="99" height="30"/>
+                            <rect key="frame" x="0.0" y="5" width="96" height="30"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="30" id="3wp-Qm-Vp5"/>
                             </constraints>
@@ -55,17 +55,14 @@
                         <constraint firstItem="hVB-2M-iYt" firstAttribute="centerY" secondItem="eki-qS-IGB" secondAttribute="centerY" id="Id4-46-ZQG"/>
                         <constraint firstAttribute="trailing" secondItem="hVB-2M-iYt" secondAttribute="trailing" id="NVd-Vs-AgW"/>
                         <constraint firstItem="hVB-2M-iYt" firstAttribute="leading" secondItem="eki-qS-IGB" secondAttribute="leading" id="jbe-j2-z9d"/>
-                        <constraint firstAttribute="height" constant="35" id="nXL-am-y6R"/>
+                        <constraint firstAttribute="height" constant="40" id="nXL-am-y6R"/>
                     </constraints>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fle-ET-bnW" userLabel="IssuerContainer">
-                    <rect key="frame" x="136" y="16" width="99" height="35"/>
+                    <rect key="frame" x="136" y="16" width="96" height="40"/>
                     <subviews>
                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="iqG-Eo-eGS" userLabel="remoteBankImage" customClass="UIImageViewAligned" customModule="MLCardDrawer" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="2.5" width="99" height="30"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="30" id="ooY-WT-yGo"/>
-                            </constraints>
+                            <rect key="frame" x="0.0" y="5" width="96" height="30"/>
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="boolean" keyPath="alignRight" value="YES"/>
                             </userDefinedRuntimeAttributes>
@@ -79,13 +76,13 @@
                     </constraints>
                 </view>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MM/AA" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AMu-xJ-OI6" customClass="CardLabel" customModule="MLCardDrawer" customModuleProvider="target">
-                    <rect key="frame" x="188" y="114.5" width="47" height="17"/>
+                    <rect key="frame" x="185" y="114.5" width="47" height="17"/>
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <view alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="89T-PX-cWX" userLabel="circleFronSecurityCodeView" customClass="CircleView" customModule="MLCardDrawer" customModuleProvider="target">
-                    <rect key="frame" x="206" y="46" width="39" height="39"/>
+                    <rect key="frame" x="203" y="46" width="39" height="39"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="39" id="35R-WB-d8w"/>
@@ -104,12 +101,12 @@
                     </userDefinedRuntimeAttributes>
                 </view>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="***" textAlignment="center" lineBreakMode="tailTruncation" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="K3c-vy-wcQ" userLabel="FrontSecurityCodeLabel" customClass="CardLabel" customModule="MLCardDrawer" customModuleProvider="target">
-                    <rect key="frame" x="218" y="58.5" width="17" height="14.5"/>
+                    <rect key="frame" x="215" y="58.5" width="17" height="14.5"/>
                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NOMBRE Y APELLIDO" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZMN-U6-Lcy" customClass="CardLabel" customModule="MLCardDrawer" customModuleProvider="target">
-                    <rect key="frame" x="21" y="112" width="166" height="22"/>
+                    <rect key="frame" x="24" y="112" width="166" height="22"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="166" id="FBH-we-hcG"/>
                     </constraints>
@@ -118,7 +115,7 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="**** **** **** ****" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="13" translatesAutoresizingMaskIntoConstraints="NO" id="EUo-1b-VQe" customClass="CardLabel" customModule="MLCardDrawer" customModuleProvider="target">
-                    <rect key="frame" x="21" y="82" width="214" height="18"/>
+                    <rect key="frame" x="24" y="82" width="208" height="18"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="18" id="cXL-fC-pUa"/>
                     </constraints>
@@ -127,7 +124,7 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="N94-Fg-ynK" userLabel="LimitView">
-                    <rect key="frame" x="120" y="28.5" width="16" height="10"/>
+                    <rect key="frame" x="120" y="31" width="16" height="10"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="16" id="Cin-WG-4v2"/>
@@ -141,9 +138,10 @@
                 <constraint firstItem="HLQ-m9-78F" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="1Vb-Vh-OMD"/>
                 <constraint firstItem="eki-qS-IGB" firstAttribute="trailing" secondItem="N94-Fg-ynK" secondAttribute="leading" id="3Bk-h4-rS6"/>
                 <constraint firstAttribute="trailing" secondItem="W2g-Ht-hY3" secondAttribute="trailing" id="42g-gv-JyA"/>
-                <constraint firstItem="ZMN-U6-Lcy" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="21" id="47K-ZK-WHj"/>
+                <constraint firstItem="ZMN-U6-Lcy" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="24" id="47K-ZK-WHj"/>
                 <constraint firstItem="EUo-1b-VQe" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" constant="12" id="5aG-Iu-7JU"/>
                 <constraint firstAttribute="bottom" secondItem="HLQ-m9-78F" secondAttribute="bottom" id="8Hh-Yk-8Vu"/>
+                <constraint firstItem="iqG-Eo-eGS" firstAttribute="height" secondItem="hVB-2M-iYt" secondAttribute="height" id="9Yf-sg-dM3"/>
                 <constraint firstItem="Fle-ET-bnW" firstAttribute="centerY" secondItem="eki-qS-IGB" secondAttribute="centerY" id="ABo-lq-EY8"/>
                 <constraint firstAttribute="bottom" secondItem="W2g-Ht-hY3" secondAttribute="bottom" id="DWY-GP-FQC"/>
                 <constraint firstItem="Fle-ET-bnW" firstAttribute="leading" secondItem="N94-Fg-ynK" secondAttribute="trailing" id="He0-Y4-rhP"/>
@@ -163,7 +161,7 @@
                 <constraint firstItem="EUo-1b-VQe" firstAttribute="leading" secondItem="ZMN-U6-Lcy" secondAttribute="leading" id="gPR-jP-sT0"/>
                 <constraint firstItem="K3c-vy-wcQ" firstAttribute="centerY" secondItem="89T-PX-cWX" secondAttribute="centerY" id="goL-C4-4Ge"/>
                 <constraint firstItem="Fle-ET-bnW" firstAttribute="height" secondItem="eki-qS-IGB" secondAttribute="height" id="l4O-bB-U3b"/>
-                <constraint firstAttribute="trailing" secondItem="AMu-xJ-OI6" secondAttribute="trailing" constant="21" id="mQC-Xx-HlH"/>
+                <constraint firstAttribute="trailing" secondItem="AMu-xJ-OI6" secondAttribute="trailing" constant="24" id="mQC-Xx-HlH"/>
                 <constraint firstItem="W2g-Ht-hY3" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="nHh-K1-jH2"/>
                 <constraint firstAttribute="bottom" secondItem="OEt-3Q-8ri" secondAttribute="bottom" id="qUC-5Y-BgY"/>
                 <constraint firstItem="eki-qS-IGB" firstAttribute="leading" secondItem="ZMN-U6-Lcy" secondAttribute="leading" id="qwy-YV-L6X"/>

--- a/Source/Classes/View/CardView/Front/FrontView.xib
+++ b/Source/Classes/View/CardView/Front/FrontView.xib
@@ -50,7 +50,7 @@
                             </userDefinedRuntimeAttributes>
                         </imageView>
                     </subviews>
-                    <color key="backgroundColor" systemColor="systemYellowColor" red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstItem="hVB-2M-iYt" firstAttribute="centerY" secondItem="eki-qS-IGB" secondAttribute="centerY" id="Id4-46-ZQG"/>
                         <constraint firstAttribute="trailing" secondItem="hVB-2M-iYt" secondAttribute="trailing" id="NVd-Vs-AgW"/>
@@ -71,7 +71,7 @@
                             </userDefinedRuntimeAttributes>
                         </imageView>
                     </subviews>
-                    <color key="backgroundColor" systemColor="systemTealColor" red="0.35294117650000001" green="0.7843137255" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstItem="iqG-Eo-eGS" firstAttribute="centerY" secondItem="Fle-ET-bnW" secondAttribute="centerY" id="IpL-Hd-bBF"/>
                         <constraint firstItem="iqG-Eo-eGS" firstAttribute="leading" secondItem="Fle-ET-bnW" secondAttribute="leading" id="LuD-zW-VGl"/>

--- a/Source/Classes/View/CardView/Front/FrontView.xib
+++ b/Source/Classes/View/CardView/Front/FrontView.xib
@@ -1,19 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="FrontView" customModule="MLCardDrawer" customModuleProvider="target">
             <connections>
                 <outlet property="animation" destination="OEt-3Q-8ri" id="0bW-HL-KCE"/>
-                <outlet property="bank" destination="DT6-XG-kaD" id="18S-hZ-7H3"/>
                 <outlet property="expirationDate" destination="AMu-xJ-OI6" id="uGb-Mm-U1i"/>
                 <outlet property="gradient" destination="W2g-Ht-hY3" id="gsv-Yn-Xxg"/>
-                <outlet property="logo" destination="oQQ-DA-UJ9" id="kdc-rZ-a1f"/>
                 <outlet property="name" destination="ZMN-U6-Lcy" id="YHC-Uc-QhK"/>
                 <outlet property="number" destination="EUo-1b-VQe" id="db1-YE-CVB"/>
                 <outlet property="overlayImage" destination="HLQ-m9-78F" id="0tL-aV-K2z"/>
@@ -40,42 +38,28 @@
                     <rect key="frame" x="0.0" y="0.0" width="256" height="158"/>
                 </imageView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eki-qS-IGB" userLabel="PaymentContainer">
-                    <rect key="frame" x="24" y="16" width="108" height="44"/>
+                    <rect key="frame" x="24" y="16" width="112" height="40"/>
                     <subviews>
-                        <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="750" image="logo" translatesAutoresizingMaskIntoConstraints="NO" id="oQQ-DA-UJ9" userLabel="paymentOptionIcon">
-                            <rect key="frame" x="0.0" y="6" width="32" height="32"/>
+                        <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="hVB-2M-iYt" userLabel="remotePaymentMethodImage" customClass="UIImageViewAligned" customModule="MLCardDrawer" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="5" width="112" height="30"/>
                             <constraints>
-                                <constraint firstAttribute="width" constant="62" id="MbH-js-AOD"/>
-                                <constraint firstAttribute="height" constant="45" id="iEE-Rp-WlX"/>
+                                <constraint firstAttribute="height" constant="30" id="3wp-Qm-Vp5"/>
                             </constraints>
-                            <variation key="default">
-                                <mask key="constraints">
-                                    <exclude reference="MbH-js-AOD"/>
-                                    <exclude reference="iEE-Rp-WlX"/>
-                                </mask>
-                            </variation>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="boolean" keyPath="alignLeft" value="YES"/>
+                            </userDefinedRuntimeAttributes>
                         </imageView>
                     </subviews>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
-                        <constraint firstItem="oQQ-DA-UJ9" firstAttribute="centerY" secondItem="eki-qS-IGB" secondAttribute="centerY" id="153-tP-xOQ"/>
-                        <constraint firstItem="oQQ-DA-UJ9" firstAttribute="leading" secondItem="eki-qS-IGB" secondAttribute="leading" id="eml-Dl-we2"/>
-                        <constraint firstAttribute="width" constant="108" id="n0A-sz-NzO"/>
-                        <constraint firstAttribute="height" constant="44" id="nXL-am-y6R"/>
+                        <constraint firstItem="hVB-2M-iYt" firstAttribute="centerY" secondItem="eki-qS-IGB" secondAttribute="centerY" id="Id4-46-ZQG"/>
+                        <constraint firstAttribute="trailing" secondItem="hVB-2M-iYt" secondAttribute="trailing" id="NVd-Vs-AgW"/>
+                        <constraint firstItem="hVB-2M-iYt" firstAttribute="leading" secondItem="eki-qS-IGB" secondAttribute="leading" id="jbe-j2-z9d"/>
+                        <constraint firstAttribute="height" constant="40" id="nXL-am-y6R"/>
                     </constraints>
                 </view>
-                <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="hVB-2M-iYt" userLabel="remotePaymentMethodImage" customClass="UIImageViewAligned" customModule="MLCardDrawer" customModuleProvider="target">
-                    <rect key="frame" x="24" y="23" width="208" height="30"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="30" id="3wp-Qm-Vp5"/>
-                        <constraint firstAttribute="width" priority="250" id="ePO-Yx-MNi"/>
-                    </constraints>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="boolean" keyPath="alignLeft" value="YES"/>
-                    </userDefinedRuntimeAttributes>
-                </imageView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fle-ET-bnW" userLabel="IssuerContainer">
-                    <rect key="frame" x="124" y="16" width="108" height="44"/>
+                    <rect key="frame" x="124" y="12" width="108" height="44"/>
                     <subviews>
                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="750" image="logo" translatesAutoresizingMaskIntoConstraints="NO" id="DT6-XG-kaD" userLabel="IssuerIcon">
                             <rect key="frame" x="76" y="6" width="32" height="32"/>
@@ -90,7 +74,7 @@
                     </constraints>
                 </view>
                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="iqG-Eo-eGS" userLabel="remoteBankImage">
-                    <rect key="frame" x="232" y="23" width="0.0" height="30"/>
+                    <rect key="frame" x="232" y="19" width="0.0" height="30"/>
                     <constraints>
                         <constraint firstAttribute="width" priority="250" id="Yok-kB-Xw6"/>
                         <constraint firstAttribute="height" constant="30" id="ooY-WT-yGo"/>
@@ -145,10 +129,10 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="N94-Fg-ynK" userLabel="LimitView">
-                    <rect key="frame" x="98" y="33" width="60" height="10"/>
+                    <rect key="frame" x="120" y="31" width="16" height="10"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="60" id="Cin-WG-4v2"/>
+                        <constraint firstAttribute="width" constant="16" id="Cin-WG-4v2"/>
                         <constraint firstAttribute="height" constant="10" id="fIi-DD-Mp8"/>
                     </constraints>
                 </view>
@@ -157,16 +141,14 @@
             <constraints>
                 <constraint firstItem="OEt-3Q-8ri" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="0si-Gj-xOe"/>
                 <constraint firstItem="HLQ-m9-78F" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="1Vb-Vh-OMD"/>
+                <constraint firstItem="eki-qS-IGB" firstAttribute="trailing" secondItem="N94-Fg-ynK" secondAttribute="trailing" id="3Bk-h4-rS6"/>
                 <constraint firstAttribute="trailing" secondItem="W2g-Ht-hY3" secondAttribute="trailing" id="42g-gv-JyA"/>
                 <constraint firstItem="ZMN-U6-Lcy" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="24" id="47K-ZK-WHj"/>
                 <constraint firstItem="EUo-1b-VQe" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" constant="12" id="5aG-Iu-7JU"/>
-                <constraint firstItem="hVB-2M-iYt" firstAttribute="trailing" secondItem="iqG-Eo-eGS" secondAttribute="trailing" id="6gW-4M-KHA"/>
                 <constraint firstAttribute="bottom" secondItem="HLQ-m9-78F" secondAttribute="bottom" id="8Hh-Yk-8Vu"/>
                 <constraint firstItem="Fle-ET-bnW" firstAttribute="top" secondItem="eki-qS-IGB" secondAttribute="bottom" constant="-44" id="9Ct-vW-n6C"/>
                 <constraint firstAttribute="bottom" secondItem="W2g-Ht-hY3" secondAttribute="bottom" id="DWY-GP-FQC"/>
-                <constraint firstItem="hVB-2M-iYt" firstAttribute="leading" secondItem="eki-qS-IGB" secondAttribute="leading" id="EWm-gj-O1e"/>
                 <constraint firstItem="iqG-Eo-eGS" firstAttribute="centerY" secondItem="Fle-ET-bnW" secondAttribute="centerY" id="FWA-Zr-C3W"/>
-                <constraint firstItem="hVB-2M-iYt" firstAttribute="centerY" secondItem="eki-qS-IGB" secondAttribute="centerY" id="Gzt-cn-GEL"/>
                 <constraint firstItem="eki-qS-IGB" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="16" id="IZx-jY-Fec"/>
                 <constraint firstItem="N94-Fg-ynK" firstAttribute="centerY" secondItem="eki-qS-IGB" secondAttribute="centerY" id="JAx-5z-yUI"/>
                 <constraint firstAttribute="bottom" secondItem="ZMN-U6-Lcy" secondAttribute="bottom" constant="24" id="JBg-7G-omn"/>

--- a/Source/Classes/View/CardView/Front/FrontView.xib
+++ b/Source/Classes/View/CardView/Front/FrontView.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <device id="retina6_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
@@ -43,7 +43,7 @@
                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="hVB-2M-iYt" userLabel="remotePaymentMethodImage" customClass="UIImageViewAligned" customModule="MLCardDrawer" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="5" width="96" height="30"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="30" id="3wp-Qm-Vp5"/>
+                                <constraint firstAttribute="height" constant="32" id="3wp-Qm-Vp5"/>
                             </constraints>
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="boolean" keyPath="alignLeft" value="YES"/>
@@ -161,6 +161,7 @@
                 <constraint firstItem="EUo-1b-VQe" firstAttribute="leading" secondItem="ZMN-U6-Lcy" secondAttribute="leading" id="gPR-jP-sT0"/>
                 <constraint firstItem="K3c-vy-wcQ" firstAttribute="centerY" secondItem="89T-PX-cWX" secondAttribute="centerY" id="goL-C4-4Ge"/>
                 <constraint firstItem="Fle-ET-bnW" firstAttribute="height" secondItem="eki-qS-IGB" secondAttribute="height" id="l4O-bB-U3b"/>
+                <constraint firstItem="hVB-2M-iYt" firstAttribute="height" secondItem="iN0-l3-epB" secondAttribute="height" multiplier="0.19" id="lzF-pf-ote"/>
                 <constraint firstAttribute="trailing" secondItem="AMu-xJ-OI6" secondAttribute="trailing" constant="24" id="mQC-Xx-HlH"/>
                 <constraint firstItem="W2g-Ht-hY3" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="nHh-K1-jH2"/>
                 <constraint firstAttribute="bottom" secondItem="OEt-3Q-8ri" secondAttribute="bottom" id="qUC-5Y-BgY"/>
@@ -173,6 +174,11 @@
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <variation key="heightClass=regular">
+                <mask key="constraints">
+                    <exclude reference="lzF-pf-ote"/>
+                </mask>
+            </variation>
             <point key="canvasLocation" x="-1416" y="-1609.2953523238382"/>
         </view>
     </objects>

--- a/Source/Classes/View/CardView/Front/MediumFrontView.xib
+++ b/Source/Classes/View/CardView/Front/MediumFrontView.xib
@@ -91,9 +91,9 @@
                     <rect key="frame" x="319" y="8" width="0.0" height="28"/>
                     <subviews>
                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DT6-XG-kaD" userLabel="remoteIssuerIcon">
-                            <rect key="frame" x="0.0" y="2" width="0.0" height="24"/>
+                            <rect key="frame" x="0.0" y="1" width="0.0" height="26"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="24" id="Tph-b1-QFh"/>
+                                <constraint firstAttribute="height" constant="26" id="Tph-b1-QFh"/>
                                 <constraint firstAttribute="width" priority="250" id="m47-dL-SRi"/>
                             </constraints>
                             <userDefinedRuntimeAttributes>
@@ -108,7 +108,6 @@
                     <constraints>
                         <constraint firstItem="DT6-XG-kaD" firstAttribute="centerY" secondItem="Fle-ET-bnW" secondAttribute="centerY" id="BT5-rW-LgL"/>
                         <constraint firstAttribute="leading" secondItem="DT6-XG-kaD" secondAttribute="leading" id="cY1-h8-Umf"/>
-                        <constraint firstAttribute="height" constant="28" id="tVL-Wf-KZV"/>
                         <constraint firstAttribute="trailing" secondItem="DT6-XG-kaD" secondAttribute="trailing" id="uUY-jM-4mL"/>
                     </constraints>
                 </view>
@@ -134,12 +133,12 @@
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ydv-Kv-9qv">
-                    <rect key="frame" x="137.5" y="21" width="60" height="2"/>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ydv-Kv-9qv" userLabel="LimitView">
+                    <rect key="frame" x="159.5" y="21" width="16" height="2"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="2" id="Gsh-cC-U6M"/>
-                        <constraint firstAttribute="width" constant="60" id="tfw-ns-ePd"/>
+                        <constraint firstAttribute="width" constant="16" id="tfw-ns-ePd"/>
                     </constraints>
                 </view>
             </subviews>
@@ -170,6 +169,7 @@
                 <constraint firstItem="eki-qS-IGB" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="12" id="fTX-vW-38x"/>
                 <constraint firstItem="EUo-1b-VQe" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="jHm-dQ-yxg" secondAttribute="trailing" constant="8" id="gsO-ph-O7d"/>
                 <constraint firstAttribute="trailing" secondItem="Fle-ET-bnW" secondAttribute="trailing" constant="16" id="kz9-Gy-UCb"/>
+                <constraint firstItem="Fle-ET-bnW" firstAttribute="height" secondItem="eki-qS-IGB" secondAttribute="height" id="n6u-9H-J8B"/>
                 <constraint firstItem="W2g-Ht-hY3" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="nHh-K1-jH2"/>
                 <constraint firstAttribute="bottom" secondItem="OEt-3Q-8ri" secondAttribute="bottom" id="qUC-5Y-BgY"/>
                 <constraint firstItem="EUo-1b-VQe" firstAttribute="centerY" secondItem="rTM-5K-tvz" secondAttribute="centerY" id="wEm-ht-3fR"/>

--- a/Source/Classes/View/CardView/Front/MediumFrontView.xib
+++ b/Source/Classes/View/CardView/Front/MediumFrontView.xib
@@ -41,12 +41,12 @@
                     <rect key="frame" x="12" y="8" width="8" height="28"/>
                     <subviews>
                         <imageView userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" placeholderIntrinsicWidth="0.0" placeholderIntrinsicHeight="20" translatesAutoresizingMaskIntoConstraints="NO" id="oQQ-DA-UJ9" userLabel="remotePaymentOptionIcon">
-                            <rect key="frame" x="0.0" y="4" width="0.0" height="20"/>
+                            <rect key="frame" x="0.0" y="2" width="0.0" height="24"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="62" id="MbH-js-AOD"/>
                                 <constraint firstAttribute="width" priority="250" id="UcB-cb-Yzl"/>
                                 <constraint firstAttribute="height" constant="45" id="iEE-Rp-WlX"/>
-                                <constraint firstAttribute="height" constant="20" id="myv-g1-EIb"/>
+                                <constraint firstAttribute="height" constant="24" id="myv-g1-EIb"/>
                             </constraints>
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="boolean" keyPath="alignLeft" value="YES"/>
@@ -62,9 +62,9 @@
                             </variation>
                         </imageView>
                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Rno-d9-ED7" userLabel="debitImage">
-                            <rect key="frame" x="8" y="4" width="0.0" height="20"/>
+                            <rect key="frame" x="8" y="2" width="0.0" height="24"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="20" id="8CQ-hA-BZc"/>
+                                <constraint firstAttribute="height" constant="24" id="8CQ-hA-BZc"/>
                                 <constraint firstAttribute="width" priority="250" id="PFE-ub-zFu"/>
                                 <constraint firstAttribute="height" constant="45" id="qbq-bq-fKE"/>
                                 <constraint firstAttribute="width" constant="62" id="tEd-am-Dms"/>
@@ -91,9 +91,9 @@
                     <rect key="frame" x="319" y="8" width="0.0" height="28"/>
                     <subviews>
                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DT6-XG-kaD" userLabel="remoteIssuerIcon">
-                            <rect key="frame" x="0.0" y="4" width="0.0" height="20"/>
+                            <rect key="frame" x="0.0" y="2" width="0.0" height="24"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="20" id="Tph-b1-QFh"/>
+                                <constraint firstAttribute="height" constant="24" id="Tph-b1-QFh"/>
                                 <constraint firstAttribute="width" priority="250" id="m47-dL-SRi"/>
                             </constraints>
                             <userDefinedRuntimeAttributes>

--- a/Source/Classes/View/CardView/Front/MediumFrontView.xib
+++ b/Source/Classes/View/CardView/Front/MediumFrontView.xib
@@ -38,15 +38,13 @@
                     <rect key="frame" x="0.0" y="0.0" width="335" height="109"/>
                 </imageView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eki-qS-IGB" userLabel="PaymentContainer">
-                    <rect key="frame" x="12" y="8" width="8" height="28"/>
+                    <rect key="frame" x="12" y="8" width="8" height="34"/>
                     <subviews>
                         <imageView userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" placeholderIntrinsicWidth="0.0" placeholderIntrinsicHeight="20" translatesAutoresizingMaskIntoConstraints="NO" id="oQQ-DA-UJ9" userLabel="remotePaymentOptionIcon">
-                            <rect key="frame" x="0.0" y="1" width="0.0" height="26"/>
+                            <rect key="frame" x="0.0" y="2" width="0.0" height="30"/>
                             <constraints>
-                                <constraint firstAttribute="width" constant="62" id="MbH-js-AOD"/>
                                 <constraint firstAttribute="width" priority="250" id="UcB-cb-Yzl"/>
-                                <constraint firstAttribute="height" constant="45" id="iEE-Rp-WlX"/>
-                                <constraint firstAttribute="height" constant="26" id="myv-g1-EIb"/>
+                                <constraint firstAttribute="height" constant="30" id="myv-g1-EIb"/>
                             </constraints>
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="boolean" keyPath="alignLeft" value="YES"/>
@@ -54,17 +52,10 @@
                                 <userDefinedRuntimeAttribute type="boolean" keyPath="alignRight" value="NO"/>
                                 <userDefinedRuntimeAttribute type="boolean" keyPath="alignBottom" value="NO"/>
                             </userDefinedRuntimeAttributes>
-                            <variation key="default">
-                                <mask key="constraints">
-                                    <exclude reference="MbH-js-AOD"/>
-                                    <exclude reference="iEE-Rp-WlX"/>
-                                </mask>
-                            </variation>
                         </imageView>
                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Rno-d9-ED7" userLabel="debitImage">
-                            <rect key="frame" x="8" y="1" width="0.0" height="26"/>
+                            <rect key="frame" x="8" y="2" width="0.0" height="30"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="26" id="8CQ-hA-BZc"/>
                                 <constraint firstAttribute="width" priority="250" id="PFE-ub-zFu"/>
                                 <constraint firstAttribute="height" constant="45" id="qbq-bq-fKE"/>
                                 <constraint firstAttribute="width" constant="62" id="tEd-am-Dms"/>
@@ -83,17 +74,17 @@
                         <constraint firstItem="Rno-d9-ED7" firstAttribute="centerY" secondItem="oQQ-DA-UJ9" secondAttribute="centerY" id="PwD-US-ZI3"/>
                         <constraint firstItem="oQQ-DA-UJ9" firstAttribute="trailing" secondItem="Rno-d9-ED7" secondAttribute="leading" constant="-8" id="cbO-wz-76f"/>
                         <constraint firstItem="oQQ-DA-UJ9" firstAttribute="leading" secondItem="eki-qS-IGB" secondAttribute="leading" id="eml-Dl-we2"/>
-                        <constraint firstAttribute="height" constant="28" id="nXL-am-y6R"/>
+                        <constraint firstItem="Rno-d9-ED7" firstAttribute="height" secondItem="oQQ-DA-UJ9" secondAttribute="height" id="jd1-Xh-GYL"/>
+                        <constraint firstAttribute="height" constant="34" id="nXL-am-y6R"/>
                         <constraint firstItem="Rno-d9-ED7" firstAttribute="trailing" secondItem="eki-qS-IGB" secondAttribute="trailing" id="yQL-3C-ks0"/>
                     </constraints>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fle-ET-bnW" userLabel="IssuerContainer">
-                    <rect key="frame" x="319" y="8" width="0.0" height="28"/>
+                    <rect key="frame" x="319" y="8" width="0.0" height="34"/>
                     <subviews>
                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DT6-XG-kaD" userLabel="remoteIssuerIcon">
-                            <rect key="frame" x="0.0" y="1" width="0.0" height="26"/>
+                            <rect key="frame" x="0.0" y="2" width="0.0" height="30"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="26" id="Tph-b1-QFh"/>
                                 <constraint firstAttribute="width" priority="250" id="m47-dL-SRi"/>
                             </constraints>
                             <userDefinedRuntimeAttributes>
@@ -134,7 +125,7 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ydv-Kv-9qv" userLabel="LimitView">
-                    <rect key="frame" x="159.5" y="21" width="16" height="2"/>
+                    <rect key="frame" x="159.5" y="24" width="16" height="2"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="2" id="Gsh-cC-U6M"/>
@@ -172,6 +163,7 @@
                 <constraint firstItem="Fle-ET-bnW" firstAttribute="height" secondItem="eki-qS-IGB" secondAttribute="height" id="n6u-9H-J8B"/>
                 <constraint firstItem="W2g-Ht-hY3" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="nHh-K1-jH2"/>
                 <constraint firstAttribute="bottom" secondItem="OEt-3Q-8ri" secondAttribute="bottom" id="qUC-5Y-BgY"/>
+                <constraint firstItem="DT6-XG-kaD" firstAttribute="height" secondItem="oQQ-DA-UJ9" secondAttribute="height" id="qYJ-pT-6yJ"/>
                 <constraint firstItem="EUo-1b-VQe" firstAttribute="centerY" secondItem="rTM-5K-tvz" secondAttribute="centerY" id="wEm-ht-3fR"/>
                 <constraint firstItem="eki-qS-IGB" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="ydv-Kv-9qv" secondAttribute="leading" constant="-80" id="yRo-9y-aW9"/>
             </constraints>
@@ -179,7 +171,7 @@
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <point key="canvasLocation" x="-1352.8" y="-1631.3343328335834"/>
+            <point key="canvasLocation" x="-1337" y="-1633"/>
         </view>
     </objects>
     <resources>

--- a/Source/Classes/View/CardView/Front/MediumFrontView.xib
+++ b/Source/Classes/View/CardView/Front/MediumFrontView.xib
@@ -41,12 +41,12 @@
                     <rect key="frame" x="12" y="8" width="8" height="28"/>
                     <subviews>
                         <imageView userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" placeholderIntrinsicWidth="0.0" placeholderIntrinsicHeight="20" translatesAutoresizingMaskIntoConstraints="NO" id="oQQ-DA-UJ9" userLabel="remotePaymentOptionIcon">
-                            <rect key="frame" x="0.0" y="2" width="0.0" height="24"/>
+                            <rect key="frame" x="0.0" y="1" width="0.0" height="26"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="62" id="MbH-js-AOD"/>
                                 <constraint firstAttribute="width" priority="250" id="UcB-cb-Yzl"/>
                                 <constraint firstAttribute="height" constant="45" id="iEE-Rp-WlX"/>
-                                <constraint firstAttribute="height" constant="24" id="myv-g1-EIb"/>
+                                <constraint firstAttribute="height" constant="26" id="myv-g1-EIb"/>
                             </constraints>
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="boolean" keyPath="alignLeft" value="YES"/>
@@ -62,9 +62,9 @@
                             </variation>
                         </imageView>
                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Rno-d9-ED7" userLabel="debitImage">
-                            <rect key="frame" x="8" y="2" width="0.0" height="24"/>
+                            <rect key="frame" x="8" y="1" width="0.0" height="26"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="24" id="8CQ-hA-BZc"/>
+                                <constraint firstAttribute="height" constant="26" id="8CQ-hA-BZc"/>
                                 <constraint firstAttribute="width" priority="250" id="PFE-ub-zFu"/>
                                 <constraint firstAttribute="height" constant="45" id="qbq-bq-fKE"/>
                                 <constraint firstAttribute="width" constant="62" id="tEd-am-Dms"/>


### PR DESCRIPTION
## CardDrawer Assets Unification
### Changes
- Medium and Large card constraints changed
- Large card now sets UIImage in the same way as image Url. (No need to worry on what image setter is being used, both works in same way)

_Disclaimer_: This only works with assets from PX`s API, or ones with similar aspect ratio.

### Screenshots
<img width="371" alt="Screen Shot 2020-08-18 at 13 10 14" src="https://user-images.githubusercontent.com/58035996/90636529-1f86e400-e201-11ea-80da-ebb0da7e44bf.png">
<img width="377" alt="Screen Shot 2020-08-18 at 13 09 58" src="https://user-images.githubusercontent.com/58035996/90636539-231a6b00-e201-11ea-91a4-a59f8ed7a78c.png">
<img width="368" alt="Screen Shot 2020-08-18 at 13 10 38" src="https://user-images.githubusercontent.com/58035996/90636542-24e42e80-e201-11ea-85f7-544150039392.png">
<img width="378" alt="Screen Shot 2020-08-18 at 13 10 45" src="https://user-images.githubusercontent.com/58035996/90636549-26adf200-e201-11ea-96cc-e6813dfa4515.png">
