### PR TITLE
Large Card Changes

### DIFF
--- a/Source/Classes/View/CardView/Front/FrontView.xib
+++ b/Source/Classes/View/CardView/Front/FrontView.xib
@@ -114,7 +114,7 @@
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MM/AA" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AMu-xJ-OI6" customClass="CardLabel" customModule="MLCardDrawer" customModuleProvider="target">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MM/AA" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AMu-xJ-OI6" customClass="CardLabel" customModule="MLCardDrawer" customModuleProvider="target">
                     <rect key="frame" x="179" y="114.5" width="53" height="17"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="53" id="6HL-Ki-gNc"/>

--- a/Source/Classes/View/CardView/Front/FrontView.xib
+++ b/Source/Classes/View/CardView/Front/FrontView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -110,15 +110,12 @@
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NOMBRE Y APELLIDO" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZMN-U6-Lcy" customClass="CardLabel" customModule="MLCardDrawer" customModuleProvider="target">
                     <rect key="frame" x="24" y="114" width="142" height="18"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="18" id="yAI-uA-q4I"/>
-                    </constraints>
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="MM/AA" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AMu-xJ-OI6" customClass="CardLabel" customModule="MLCardDrawer" customModuleProvider="target">
-                    <rect key="frame" x="184" y="114.5" width="53" height="17"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MM/AA" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AMu-xJ-OI6" customClass="CardLabel" customModule="MLCardDrawer" customModuleProvider="target">
+                    <rect key="frame" x="179" y="114.5" width="53" height="17"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="53" id="6HL-Ki-gNc"/>
                     </constraints>
@@ -184,7 +181,7 @@
                     <exclude reference="lzF-pf-ote"/>
                 </mask>
             </variation>
-            <point key="canvasLocation" x="-1416" y="-1609.2953523238382"/>
+            <point key="canvasLocation" x="-1417.5" y="-1609.8591549295775"/>
         </view>
     </objects>
     <resources>


### PR DESCRIPTION
## Changes
- Large Card: height constraint in name's label removed due an issue with intrinsic size of the whole card (was appearing with a different aspect ratio than wanted)

## Screenshots
| Before | Now |
| --- | --- |
|<img width="363" alt="Screen Shot 2020-08-25 at 13 50 49" src="https://user-images.githubusercontent.com/58035996/91321445-fe8c3900-e794-11ea-9f09-e955fc0afca4.png">|<img width="364" alt="Screen Shot 2020-08-26 at 12 09 50" src="https://user-images.githubusercontent.com/58035996/91321520-1663bd00-e795-11ea-9856-be66ce9e2ded.png">|