### PR TITLE
Release/1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Release (1.6.1)](https://github.com/mercadolibre/meli-card-drawer-ios/releases/tag/1.6.1)
+### 🚀 Fix 🚀
+- Adjust protocols to avoid change implementation on third parties
+
 ## [Release (1.6.0)](https://github.com/mercadolibre/meli-card-drawer-ios/releases/tag/1.6.0)
 ### 🚀 GenericCard 🚀
 - New protocols CreditCardUI and GenericCardUI

--- a/MLCardDrawer.podspec
+++ b/MLCardDrawer.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MLCardDrawer"
-  s.version          = "1.6.0"
+  s.version          = "1.6.1"
   s.summary          = "MLCardDrawer for iOS"
   s.homepage         = "https://github.com/mercadolibre/meli-card-drawer-ios"
   s.license          = { :type => "MIT", :file => "LICENSE" }


### PR DESCRIPTION
## [Release (1.6.1)](https://github.com/mercadolibre/meli-card-drawer-ios/releases/tag/1.6.1)
### 🚀 Fix 🚀
- Adjust protocols to avoid change implementation on third parties