### PR TITLE
Release 1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Release (1.7.3)](https://github.com/mercadolibre/meli-card-drawer-ios/releases/tag/1.7.3)
+### 🚀 Feature 🚀
+- Changed disclaimer from String to NSAttributedString
+
 ## [Release (1.7.2)](https://github.com/mercadolibre/meli-card-drawer-ios/releases/tag/1.7.2)
 ### 🚀 Feature 🚀
 - Added a disclaimer label in MediumFrontView

--- a/MLCardDrawer.podspec
+++ b/MLCardDrawer.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MLCardDrawer"
-  s.version          = "1.7.2"
+  s.version          = "1.7.3"
   s.summary          = "MLCardDrawer for iOS"
   s.homepage         = "https://github.com/mercadolibre/meli-card-drawer-ios"
   s.license          = { :type => "MIT", :file => "LICENSE" }


### PR DESCRIPTION
## [Release (1.7.3)](https://github.com/mercadolibre/meli-card-drawer-ios/releases/tag/1.7.3)
### 🚀 Feature 🚀
- Changed disclaimer from String to NSAttributedString