### PR TITLE
(Fixed) - Fixing issue when removing card observers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Release (1.8.4)](https://github.com/mercadolibre/meli-card-drawer-ios/releases/tag/1.8.4)
+### 🚀 Fix 🚀
+- Fix crash for MediumFrontView
+
 ## [Release (1.8.3)](https://github.com/mercadolibre/meli-card-drawer-ios/releases/tag/1.8.3)
 ### 🚀 Fix 🚀
 - Fix generic card labels spacing

--- a/MLCardDrawer.podspec
+++ b/MLCardDrawer.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MLCardDrawer"
-  s.version          = "1.8.3"
+  s.version          = "1.8.4"
   s.summary          = "MLCardDrawer for iOS"
   s.homepage         = "https://github.com/mercadolibre/meli-card-drawer-ios"
   s.license          = { :type => "MIT", :file => "LICENSE" }

--- a/Source/Classes/View/CardView/Front/MediumFrontView.swift
+++ b/Source/Classes/View/CardView/Front/MediumFrontView.swift
@@ -34,8 +34,13 @@ class MediumFrontView: CardView {
     }
 
     deinit {
-        removeObserver(number, forKeyPath: #keyPath(model.number))
-        removeObserver(nameLabel, forKeyPath: #keyPath(model.name))
+        guard model != nil else { return }
+        number.flatMap {
+            removeObserver($0, forKeyPath: #keyPath(model.number))
+        }
+        nameLabel.flatMap {
+            removeObserver($0, forKeyPath: #keyPath(model.name))
+        }
     }
 }
 


### PR DESCRIPTION
Adding `nil` validation when removing observers in the class `MediumFrontView` in order to avoid a crash caused by attempting to use objects with `nil` values.