### PR TITLE
[Bugfix] Renaming CardView for Objc classes

### DIFF
--- a/Source/Classes/View/CardView/CardView.swift
+++ b/Source/Classes/View/CardView/CardView.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+@objc(MLCardView)
 public class CardView: UIView, BasicCard {
 
     @IBOutlet weak var animation: UIView!


### PR DESCRIPTION
Renaming `CardView` for Objc classes in order to avoid issues with duplicated names with other libraries like `HomeSectionsApi`.