### PR TITLE
Bugfix/pxn 4523 error bezierpath tagbottom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+## Fix
+- fix error in tagbottom bezierpath when card with tagbottom is removed from screen
+
 ## [Release (1.11.0)](https://github.com/mercadolibre/meli-card-drawer-ios/releases/tag/1.11.0)
 ## Added
 - Card Balance Component

--- a/Source/Classes/View/TagBottom.swift
+++ b/Source/Classes/View/TagBottom.swift
@@ -45,7 +45,7 @@ public class TagBottom: UILabel {
         
     private func addInsets(to size: CGSize) -> CGSize {
         let width = size.width + leftInset + rightInset
-        let height = size.height + topInset + bottomInset
+        let height = size.height + topInset + bottomInset - 2
         return CGSize(width: width, height: height)
     }
     

--- a/Source/Classes/View/TagBottom.swift
+++ b/Source/Classes/View/TagBottom.swift
@@ -31,11 +31,22 @@ public class TagBottom: UILabel {
         }
     }
     
+    public override func sizeThatFits(_ size: CGSize) -> CGSize {
+        return addInsets(to: super.sizeThatFits(size))
+    }
+
+    
     public override func didMoveToWindow() {
         let path = UIBezierPath(roundedRect: self.bounds, byRoundingCorners: [.topLeft, .bottomLeft], cornerRadii: CGSize(width: self.bounds.height/2, height: self.bounds.height/2))
         let mask = CAShapeLayer()
         mask.path = path.cgPath
         self.layer.mask = mask
+    }
+        
+    private func addInsets(to size: CGSize) -> CGSize {
+        let width = size.width + leftInset + rightInset
+        let height = size.height + topInset + bottomInset
+        return CGSize(width: width, height: height)
     }
     
 }


### PR DESCRIPTION
- fix error in tagbottom bezierpath when card with tagbottom is removed from screen

![image](https://user-images.githubusercontent.com/94566493/179273594-05f112d2-af12-41fa-b527-5dc3065380da.png)
![image](https://user-images.githubusercontent.com/94566493/179273682-6d7e148c-1c55-4c02-913e-8e5373713c6e.png)
