### PR TITLE
(Added)[PXN-4600] - Clean old layout  from front cards

### DIFF
--- a/Source/Classes/View/CardView/Front/FrontView.swift
+++ b/Source/Classes/View/CardView/Front/FrontView.swift
@@ -51,7 +51,6 @@ class FrontView: CardView {
         securityCode.formatter = Mask(pattern: [cardUI.securityCodePattern])
         name.formatter = Mask(placeholder: cardUI.placeholderName)
         number.formatter = Mask(pattern: cardUI.cardPattern, digits: model?.lastDigits)
-        expirationDate.formatter = Mask(placeholder: cardUI.placeholderExpiration)
     }
     
     private func setupCardElements(_ cardUI: CardUI) {
@@ -72,14 +71,12 @@ class FrontView: CardView {
     override func addObservers() {
         addObserver(name, forKeyPath: #keyPath(model.name), options: .new, context: nil)
         addObserver(number, forKeyPath: #keyPath(model.number), options: .new, context: nil)
-        addObserver(expirationDate, forKeyPath: #keyPath(model.expiration), options: .new, context: nil)
         addObserver(securityCode, forKeyPath: #keyPath(model.securityCode), options: .new, context: nil)
     }
 
     deinit {
         removeObserver(name, forKeyPath: #keyPath(model.name))
         removeObserver(number, forKeyPath: #keyPath(model.number))
-        removeObserver(expirationDate, forKeyPath: #keyPath(model.expiration))
         removeObserver(securityCode, forKeyPath: #keyPath(model.securityCode))
     }
     
@@ -242,7 +239,7 @@ extension FrontView {
         if !(cardUI is CustomCardDrawerUI) {
             Animator.overlay(on: self,
                              cardUI: cardUI,
-                             views: [bankImage, expirationDate, paymentMethodImage, name, number, securityCode],
+                             views: [bankImage, paymentMethodImage, name, number, securityCode],
                              complete: {[weak self] in
                                 self?.setupUI(cardUI)
             })

--- a/Source/Classes/View/CardView/Front/FrontView.xib
+++ b/Source/Classes/View/CardView/Front/FrontView.xib
@@ -13,13 +13,6 @@
                 <outlet property="bankImage" destination="iqG-Eo-eGS" id="OQn-yr-FpB"/>
                 <outlet property="cardBalanceContainer" destination="PCI-4F-tTc" id="3rT-8l-Mjz"/>
                 <outlet property="gradient" destination="W2g-Ht-hY3" id="gsv-Yn-Xxg"/>
-                <outlet property="name" destination="ZMN-U6-Lcy" id="YHC-Uc-QhK"/>
-                <outlet property="nameBottomToSuperviewConstraint" destination="Zqi-vG-kju" id="scP-g1-TgR"/>
-                <outlet property="nameLeadingConstraint" destination="47K-ZK-WHj" id="vgY-kj-uiS"/>
-                <outlet property="nameToNumberTopConstraint" destination="uAh-2S-u7H" id="3yg-Lu-kAi"/>
-                <outlet property="number" destination="EUo-1b-VQe" id="db1-YE-CVB"/>
-                <outlet property="numberToNameLeadingConstraint" destination="gPR-jP-sT0" id="8mx-sw-cSb"/>
-                <outlet property="numberTrailingConstraint" destination="7Fn-mR-gxB" id="sNk-Hl-Krn"/>
                 <outlet property="overlayImage" destination="HLQ-m9-78F" id="0tL-aV-K2z"/>
                 <outlet property="paymentMethodImage" destination="hVB-2M-iYt" id="Tr2-It-Ho8"/>
                 <outlet property="safeZone" destination="L4o-xR-CfT" id="l7R-Vk-asA"/>
@@ -82,7 +75,7 @@
                     </constraints>
                 </view>
                 <view alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="89T-PX-cWX" userLabel="circleFronSecurityCodeView" customClass="CircleView" customModule="MLCardDrawer">
-                    <rect key="frame" x="203" y="46" width="39" height="39"/>
+                    <rect key="frame" x="203" y="40" width="39" height="39"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="39" id="35R-WB-d8w"/>
@@ -101,23 +94,8 @@
                     </userDefinedRuntimeAttributes>
                 </view>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="***" textAlignment="center" lineBreakMode="tailTruncation" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="K3c-vy-wcQ" userLabel="FrontSecurityCodeLabel" customClass="CardLabel" customModule="MLCardDrawer">
-                    <rect key="frame" x="215" y="58.5" width="17" height="14"/>
+                    <rect key="frame" x="215" y="52.5" width="17" height="14"/>
                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="right" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="**** **** **** ****" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="13" translatesAutoresizingMaskIntoConstraints="NO" id="EUo-1b-VQe" customClass="CardLabel" customModule="MLCardDrawer">
-                    <rect key="frame" x="24" y="82" width="208" height="18"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="18" id="cXL-fC-pUa"/>
-                    </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="19"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" text="NOMBRE Y APELLIDO" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZMN-U6-Lcy" customClass="CardLabel" customModule="MLCardDrawer">
-                    <rect key="frame" x="24" y="114" width="142" height="18"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                    <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="N94-Fg-ynK" userLabel="LimitView">
@@ -144,13 +122,10 @@
             <constraints>
                 <constraint firstItem="OEt-3Q-8ri" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="0si-Gj-xOe"/>
                 <constraint firstItem="HLQ-m9-78F" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="1Vb-Vh-OMD"/>
-                <constraint firstItem="L4o-xR-CfT" firstAttribute="top" secondItem="EUo-1b-VQe" secondAttribute="bottom" constant="12" id="1Xh-5H-yAY"/>
+                <constraint firstItem="L4o-xR-CfT" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="bottom" constant="-46" id="1Xh-5H-yAY"/>
                 <constraint firstItem="eki-qS-IGB" firstAttribute="trailing" secondItem="N94-Fg-ynK" secondAttribute="leading" id="3Bk-h4-rS6"/>
                 <constraint firstItem="L4o-xR-CfT" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="3tQ-5Q-dQp"/>
                 <constraint firstAttribute="trailing" secondItem="W2g-Ht-hY3" secondAttribute="trailing" id="42g-gv-JyA"/>
-                <constraint firstItem="ZMN-U6-Lcy" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="24" id="47K-ZK-WHj"/>
-                <constraint firstItem="EUo-1b-VQe" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" constant="12" id="5aG-Iu-7JU"/>
-                <constraint firstAttribute="trailing" secondItem="EUo-1b-VQe" secondAttribute="trailing" constant="24" id="7Fn-mR-gxB"/>
                 <constraint firstAttribute="bottom" secondItem="HLQ-m9-78F" secondAttribute="bottom" id="8Hh-Yk-8Vu"/>
                 <constraint firstItem="iqG-Eo-eGS" firstAttribute="height" secondItem="hVB-2M-iYt" secondAttribute="height" id="9Yf-sg-dM3"/>
                 <constraint firstItem="Fle-ET-bnW" firstAttribute="centerY" secondItem="eki-qS-IGB" secondAttribute="centerY" id="ABo-lq-EY8"/>
@@ -166,10 +141,8 @@
                 <constraint firstAttribute="trailing" secondItem="HLQ-m9-78F" secondAttribute="trailing" id="RP9-3G-Afk"/>
                 <constraint firstItem="HLQ-m9-78F" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="Roz-63-Y1h"/>
                 <constraint firstItem="K3c-vy-wcQ" firstAttribute="trailing" secondItem="iN0-l3-epB" secondAttribute="trailing" constant="-24" id="V0X-Zg-lw3"/>
-                <constraint firstItem="Fle-ET-bnW" firstAttribute="trailing" secondItem="EUo-1b-VQe" secondAttribute="trailing" id="ZmV-6D-57z"/>
-                <constraint firstAttribute="bottom" secondItem="ZMN-U6-Lcy" secondAttribute="bottom" constant="26" id="Zqi-vG-kju"/>
+                <constraint firstItem="Fle-ET-bnW" firstAttribute="trailing" secondItem="iN0-l3-epB" secondAttribute="trailing" constant="-24" id="ZmV-6D-57z"/>
                 <constraint firstItem="OEt-3Q-8ri" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="eq2-Nh-tjE"/>
-                <constraint firstItem="EUo-1b-VQe" firstAttribute="leading" secondItem="ZMN-U6-Lcy" secondAttribute="leading" id="gPR-jP-sT0"/>
                 <constraint firstItem="K3c-vy-wcQ" firstAttribute="centerY" secondItem="89T-PX-cWX" secondAttribute="centerY" id="goL-C4-4Ge"/>
                 <constraint firstItem="PCI-4F-tTc" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="16" id="kyy-9T-fcv"/>
                 <constraint firstItem="Fle-ET-bnW" firstAttribute="height" secondItem="eki-qS-IGB" secondAttribute="height" id="l4O-bB-U3b"/>
@@ -177,10 +150,9 @@
                 <constraint firstItem="hVB-2M-iYt" firstAttribute="height" secondItem="iN0-l3-epB" secondAttribute="height" multiplier="0.19" id="lzF-pf-ote"/>
                 <constraint firstItem="W2g-Ht-hY3" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="nHh-K1-jH2"/>
                 <constraint firstAttribute="bottom" secondItem="OEt-3Q-8ri" secondAttribute="bottom" id="qUC-5Y-BgY"/>
-                <constraint firstItem="eki-qS-IGB" firstAttribute="leading" secondItem="ZMN-U6-Lcy" secondAttribute="leading" id="qwy-YV-L6X"/>
-                <constraint firstItem="ZMN-U6-Lcy" firstAttribute="top" secondItem="EUo-1b-VQe" secondAttribute="bottom" constant="14" id="uAh-2S-u7H"/>
+                <constraint firstItem="eki-qS-IGB" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="24" id="qwy-YV-L6X"/>
                 <constraint firstItem="89T-PX-cWX" firstAttribute="centerX" secondItem="K3c-vy-wcQ" secondAttribute="centerX" constant="-1" id="w6D-0s-Beo"/>
-                <constraint firstItem="EUo-1b-VQe" firstAttribute="top" secondItem="89T-PX-cWX" secondAttribute="bottom" constant="-3" id="weF-sf-C3X"/>
+                <constraint firstItem="89T-PX-cWX" firstAttribute="bottom" secondItem="iN0-l3-epB" secondAttribute="centerY" id="weF-sf-C3X"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <nil key="simulatedTopBarMetrics"/>

--- a/Source/Classes/View/CardView/Front/FrontView.xib
+++ b/Source/Classes/View/CardView/Front/FrontView.xib
@@ -107,7 +107,7 @@
                     </constraints>
                 </view>
                 <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L4o-xR-CfT" userLabel="SafeZone">
-                    <rect key="frame" x="0.0" y="112" width="256" height="46"/>
+                    <rect key="frame" x="0.0" y="98" width="256" height="60"/>
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.15466148739769348" colorSpace="custom" customColorSpace="sRGB"/>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PCI-4F-tTc" customClass="CardBalance" customModule="MLCardDrawer">
@@ -122,7 +122,7 @@
             <constraints>
                 <constraint firstItem="OEt-3Q-8ri" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="0si-Gj-xOe"/>
                 <constraint firstItem="HLQ-m9-78F" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="1Vb-Vh-OMD"/>
-                <constraint firstItem="L4o-xR-CfT" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="bottom" constant="-46" id="1Xh-5H-yAY"/>
+                <constraint firstItem="L4o-xR-CfT" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="bottom" constant="-60" id="1Xh-5H-yAY"/>
                 <constraint firstItem="eki-qS-IGB" firstAttribute="trailing" secondItem="N94-Fg-ynK" secondAttribute="leading" id="3Bk-h4-rS6"/>
                 <constraint firstItem="L4o-xR-CfT" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="3tQ-5Q-dQp"/>
                 <constraint firstAttribute="trailing" secondItem="W2g-Ht-hY3" secondAttribute="trailing" id="42g-gv-JyA"/>

--- a/Source/Classes/View/CardView/Front/FrontView.xib
+++ b/Source/Classes/View/CardView/Front/FrontView.xib
@@ -107,7 +107,7 @@
                     </constraints>
                 </view>
                 <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L4o-xR-CfT" userLabel="SafeZone">
-                    <rect key="frame" x="0.0" y="98" width="256" height="60"/>
+                    <rect key="frame" x="0.0" y="90" width="256" height="68"/>
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.15466148739769348" colorSpace="custom" customColorSpace="sRGB"/>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PCI-4F-tTc" customClass="CardBalance" customModule="MLCardDrawer">
@@ -122,7 +122,7 @@
             <constraints>
                 <constraint firstItem="OEt-3Q-8ri" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="0si-Gj-xOe"/>
                 <constraint firstItem="HLQ-m9-78F" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="1Vb-Vh-OMD"/>
-                <constraint firstItem="L4o-xR-CfT" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="bottom" constant="-60" id="1Xh-5H-yAY"/>
+                <constraint firstItem="L4o-xR-CfT" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="bottom" constant="-68" id="1Xh-5H-yAY"/>
                 <constraint firstItem="eki-qS-IGB" firstAttribute="trailing" secondItem="N94-Fg-ynK" secondAttribute="leading" id="3Bk-h4-rS6"/>
                 <constraint firstItem="L4o-xR-CfT" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="3tQ-5Q-dQp"/>
                 <constraint firstAttribute="trailing" secondItem="W2g-Ht-hY3" secondAttribute="trailing" id="42g-gv-JyA"/>

--- a/Source/Classes/View/CardView/Front/FrontView.xib
+++ b/Source/Classes/View/CardView/Front/FrontView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -12,7 +12,6 @@
                 <outlet property="animation" destination="OEt-3Q-8ri" id="0bW-HL-KCE"/>
                 <outlet property="bankImage" destination="iqG-Eo-eGS" id="OQn-yr-FpB"/>
                 <outlet property="cardBalanceContainer" destination="PCI-4F-tTc" id="3rT-8l-Mjz"/>
-                <outlet property="expirationDate" destination="AMu-xJ-OI6" id="uGb-Mm-U1i"/>
                 <outlet property="gradient" destination="W2g-Ht-hY3" id="gsv-Yn-Xxg"/>
                 <outlet property="name" destination="ZMN-U6-Lcy" id="YHC-Uc-QhK"/>
                 <outlet property="nameBottomToSuperviewConstraint" destination="Zqi-vG-kju" id="scP-g1-TgR"/>
@@ -121,15 +120,6 @@
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MM/AA" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AMu-xJ-OI6" customClass="CardLabel" customModule="MLCardDrawer">
-                    <rect key="frame" x="179" y="114.5" width="53" height="17"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="53" id="6HL-Ki-gNc"/>
-                    </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="N94-Fg-ynK" userLabel="LimitView">
                     <rect key="frame" x="120" y="31" width="16" height="10"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -164,7 +154,6 @@
                 <constraint firstAttribute="bottom" secondItem="HLQ-m9-78F" secondAttribute="bottom" id="8Hh-Yk-8Vu"/>
                 <constraint firstItem="iqG-Eo-eGS" firstAttribute="height" secondItem="hVB-2M-iYt" secondAttribute="height" id="9Yf-sg-dM3"/>
                 <constraint firstItem="Fle-ET-bnW" firstAttribute="centerY" secondItem="eki-qS-IGB" secondAttribute="centerY" id="ABo-lq-EY8"/>
-                <constraint firstItem="AMu-xJ-OI6" firstAttribute="height" secondItem="ZMN-U6-Lcy" secondAttribute="height" multiplier="0.944444" id="BYS-Z7-qkh"/>
                 <constraint firstAttribute="bottom" secondItem="W2g-Ht-hY3" secondAttribute="bottom" id="DWY-GP-FQC"/>
                 <constraint firstItem="Fle-ET-bnW" firstAttribute="leading" secondItem="N94-Fg-ynK" secondAttribute="trailing" id="He0-Y4-rhP"/>
                 <constraint firstItem="eki-qS-IGB" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="16" id="IZx-jY-Fec"/>
@@ -176,8 +165,7 @@
                 <constraint firstItem="N94-Fg-ynK" firstAttribute="centerX" secondItem="HLQ-m9-78F" secondAttribute="centerX" id="QpT-U2-dW4"/>
                 <constraint firstAttribute="trailing" secondItem="HLQ-m9-78F" secondAttribute="trailing" id="RP9-3G-Afk"/>
                 <constraint firstItem="HLQ-m9-78F" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="Roz-63-Y1h"/>
-                <constraint firstItem="K3c-vy-wcQ" firstAttribute="trailing" secondItem="AMu-xJ-OI6" secondAttribute="trailing" id="V0X-Zg-lw3"/>
-                <constraint firstItem="AMu-xJ-OI6" firstAttribute="centerY" secondItem="ZMN-U6-Lcy" secondAttribute="centerY" id="YcG-Cp-uXh"/>
+                <constraint firstItem="K3c-vy-wcQ" firstAttribute="trailing" secondItem="iN0-l3-epB" secondAttribute="trailing" constant="-24" id="V0X-Zg-lw3"/>
                 <constraint firstItem="Fle-ET-bnW" firstAttribute="trailing" secondItem="EUo-1b-VQe" secondAttribute="trailing" id="ZmV-6D-57z"/>
                 <constraint firstAttribute="bottom" secondItem="ZMN-U6-Lcy" secondAttribute="bottom" constant="26" id="Zqi-vG-kju"/>
                 <constraint firstItem="OEt-3Q-8ri" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="eq2-Nh-tjE"/>
@@ -187,11 +175,9 @@
                 <constraint firstItem="Fle-ET-bnW" firstAttribute="height" secondItem="eki-qS-IGB" secondAttribute="height" id="l4O-bB-U3b"/>
                 <constraint firstAttribute="trailing" secondItem="PCI-4F-tTc" secondAttribute="trailing" constant="16" id="lWd-44-e2Y"/>
                 <constraint firstItem="hVB-2M-iYt" firstAttribute="height" secondItem="iN0-l3-epB" secondAttribute="height" multiplier="0.19" id="lzF-pf-ote"/>
-                <constraint firstAttribute="trailing" secondItem="AMu-xJ-OI6" secondAttribute="trailing" constant="24" id="mQC-Xx-HlH"/>
                 <constraint firstItem="W2g-Ht-hY3" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="nHh-K1-jH2"/>
                 <constraint firstAttribute="bottom" secondItem="OEt-3Q-8ri" secondAttribute="bottom" id="qUC-5Y-BgY"/>
                 <constraint firstItem="eki-qS-IGB" firstAttribute="leading" secondItem="ZMN-U6-Lcy" secondAttribute="leading" id="qwy-YV-L6X"/>
-                <constraint firstItem="AMu-xJ-OI6" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="ZMN-U6-Lcy" secondAttribute="trailing" constant="8" id="smX-By-8il"/>
                 <constraint firstItem="ZMN-U6-Lcy" firstAttribute="top" secondItem="EUo-1b-VQe" secondAttribute="bottom" constant="14" id="uAh-2S-u7H"/>
                 <constraint firstItem="89T-PX-cWX" firstAttribute="centerX" secondItem="K3c-vy-wcQ" secondAttribute="centerX" constant="-1" id="w6D-0s-Beo"/>
                 <constraint firstItem="EUo-1b-VQe" firstAttribute="top" secondItem="89T-PX-cWX" secondAttribute="bottom" constant="-3" id="weF-sf-C3X"/>

--- a/Source/Classes/View/CardView/Front/MediumFrontView.swift
+++ b/Source/Classes/View/CardView/Front/MediumFrontView.swift
@@ -3,14 +3,9 @@ import UIKit
 class MediumFrontView: CardView {
     @IBOutlet weak var paymentMethodImage: UIImageView!
     @IBOutlet weak var issuerImage: UIImageView!
-    @IBOutlet weak var number: CardLabel!
     @IBOutlet weak var debitImage: UIImageView!
-    @IBOutlet weak var nameLabel: CardLabel!
     @IBOutlet weak var chevronIcon: UIImageView!
     @IBOutlet weak var disclaimer: CardLabel!
-    
-    @IBOutlet weak var numberTrailingConstraint: NSLayoutConstraint!
-    
     @IBOutlet weak var cardBalanceContainer: CardBalance!
 
     private var shineView: ShineView?
@@ -24,25 +19,9 @@ class MediumFrontView: CardView {
         setDebitImage(cardUI)
         setupCardLabels(cardUI)
         setupChevron(cardUI)
-        setupFormatters(cardUI)
         
         cardBackground = cardUI.cardBackgroundColor
         setupCustomOverlayImage(cardUI)
-    }
-    
-    override func addObservers() {
-        addObserver(nameLabel, forKeyPath: #keyPath(model.name), options: .new, context: nil)
-        addObserver(number, forKeyPath: #keyPath(model.number), options: .new, context: nil)
-    }
-
-    deinit {
-        guard model != nil else { return }
-        number.flatMap {
-            removeObserver($0, forKeyPath: #keyPath(model.number))
-        }
-        nameLabel.flatMap {
-            removeObserver($0, forKeyPath: #keyPath(model.name))
-        }
     }
     
     override func addCardBalance(_ model: CardBalanceModel, _ showBalance: Bool, _ delegate: CardBalanceDelegate) {
@@ -53,21 +32,16 @@ class MediumFrontView: CardView {
     }
 }
 
-// MARK: Publics
 extension MediumFrontView {
     override func setupAnimated(_ cardUI: CardUI) {
         Animator.overlay(on: self,
                          cardUI: cardUI,
-                         views: [issuerImage, paymentMethodImage, debitImage, nameLabel, number, chevronIcon],
+                         views: [issuerImage, paymentMethodImage, debitImage, chevronIcon],
                          complete: {[weak self] in
                             self?.setupUI(cardUI)
         })
     }
     
-    private func setupFormatters(_ cardUI: CardUI) {
-        number.formatter = Mask(pattern: cardUI.cardPattern, digits: model?.lastDigits)
-    }
-
     private func setPaymentMethodImage(_ cardUI: CardUI) {
         paymentMethodImage.image = nil
         if let imageUrl = cardUI.cardLogoImageUrl as? String, !imageUrl.isEmpty  {
@@ -107,7 +81,6 @@ extension MediumFrontView {
     
     private func setupChevron(_ cardUI: CardUI) {
         showChevron(cardUI.showChevron == true)
-        
         chevronIcon.image = chevronIcon.image?.withRenderingMode(.alwaysTemplate)
         chevronIcon.tintColor = getChevronColor(cardUI)
     }
@@ -122,13 +95,6 @@ extension MediumFrontView {
     }
     
     private func setupCardLabels(_ cardUI: CardUI) {
-        nameLabel.setup(model?.name ?? "", FontFactory.font(cardUI), customLabelFontName: self.customLabelFontName)
-        nameLabel.font = nameLabel.font.withSize(12)
-        
-        number.dynamicSlice = false
-        number.setup(model?.number ?? "", FontFactory.font(cardUI, shadow: true), customLabelFontName: self.customLabelFontName)
-        number.font = number.font.withSize(12)
-        
         disclaimer.font = UIFont.systemFont(ofSize: 12, weight: .regular)
         disclaimer.textColor = cardUI.cardFontColor
         disclaimer.attributedText = model?.disclaimer
@@ -149,7 +115,6 @@ private extension MediumFrontView {
     }
     
     func showChevron(_ value: Bool) {
-        numberTrailingConstraint.priority = value ? .defaultLow : .required
         chevronIcon.isHidden = !value
     }
     

--- a/Source/Classes/View/CardView/Front/MediumFrontView.swift
+++ b/Source/Classes/View/CardView/Front/MediumFrontView.swift
@@ -24,6 +24,8 @@ class MediumFrontView: CardView {
         setupCustomOverlayImage(cardUI)
     }
     
+    override func addObservers() {}
+    
     override func addCardBalance(_ model: CardBalanceModel, _ showBalance: Bool, _ delegate: CardBalanceDelegate) {
         cardBalanceContainer.model = model
         cardBalanceContainer.showBalance = showBalance

--- a/Source/Classes/View/CardView/Front/MediumFrontView.xib
+++ b/Source/Classes/View/CardView/Front/MediumFrontView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,9 +16,6 @@
                 <outlet property="disclaimer" destination="8Sm-pj-7B1" id="cIY-dG-mPV"/>
                 <outlet property="gradient" destination="W2g-Ht-hY3" id="gsv-Yn-Xxg"/>
                 <outlet property="issuerImage" destination="DT6-XG-kaD" id="e3a-8s-cug"/>
-                <outlet property="nameLabel" destination="jHm-dQ-yxg" id="uPG-Zu-22n"/>
-                <outlet property="number" destination="EUo-1b-VQe" id="db1-YE-CVB"/>
-                <outlet property="numberTrailingConstraint" destination="Gin-mg-ylf" id="K0h-oE-Rn3"/>
                 <outlet property="overlayImage" destination="HLQ-m9-78F" id="0tL-aV-K2z"/>
                 <outlet property="paymentMethodImage" destination="oQQ-DA-UJ9" id="WyN-hY-utV"/>
             </connections>
@@ -104,15 +101,6 @@
                         <constraint firstAttribute="trailing" secondItem="DT6-XG-kaD" secondAttribute="trailing" id="uUY-jM-4mL"/>
                     </constraints>
                 </view>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="**** 1234" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="13" translatesAutoresizingMaskIntoConstraints="NO" id="EUo-1b-VQe" customClass="CardLabel" customModule="MLCardDrawer">
-                    <rect key="frame" x="220" y="78" width="81" height="18"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="18" id="cXL-fC-pUa"/>
-                    </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="19"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="MPCLChevron" translatesAutoresizingMaskIntoConstraints="NO" id="rTM-5K-tvz">
                     <rect key="frame" x="305" y="79" width="16" height="16"/>
                     <constraints>
@@ -120,12 +108,6 @@
                         <constraint firstAttribute="height" constant="16" id="jYZ-Kw-Ni4"/>
                     </constraints>
                 </imageView>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="JUAN CARLOS PASMAN" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jHm-dQ-yxg" customClass="CardLabel" customModule="MLCardDrawer">
-                    <rect key="frame" x="12" y="76.5" width="187" height="21"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ydv-Kv-9qv" userLabel="LimitView">
                     <rect key="frame" x="159.5" y="24" width="16" height="2"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -152,9 +134,7 @@
             <constraints>
                 <constraint firstItem="bpO-8l-NNN" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="16" id="01V-kL-rXv"/>
                 <constraint firstItem="OEt-3Q-8ri" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="0si-Gj-xOe"/>
-                <constraint firstItem="rTM-5K-tvz" firstAttribute="leading" secondItem="EUo-1b-VQe" secondAttribute="trailing" priority="999" constant="4" id="0zC-ui-NlW"/>
                 <constraint firstItem="HLQ-m9-78F" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="1Vb-Vh-OMD"/>
-                <constraint firstItem="jHm-dQ-yxg" firstAttribute="centerY" secondItem="EUo-1b-VQe" secondAttribute="centerY" id="211-Ov-idZ"/>
                 <constraint firstAttribute="trailing" secondItem="W2g-Ht-hY3" secondAttribute="trailing" id="42g-gv-JyA"/>
                 <constraint firstItem="ydv-Kv-9qv" firstAttribute="centerY" secondItem="eki-qS-IGB" secondAttribute="centerY" id="7Zg-3b-Pi0"/>
                 <constraint firstAttribute="bottom" secondItem="HLQ-m9-78F" secondAttribute="bottom" id="8Hh-Yk-8Vu"/>
@@ -162,8 +142,6 @@
                 <constraint firstAttribute="trailing" secondItem="bpO-8l-NNN" secondAttribute="trailing" constant="16" id="9aM-9N-APw"/>
                 <constraint firstItem="Fle-ET-bnW" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="ydv-Kv-9qv" secondAttribute="trailing" id="Be9-gl-Kp9"/>
                 <constraint firstAttribute="bottom" secondItem="W2g-Ht-hY3" secondAttribute="bottom" id="DWY-GP-FQC"/>
-                <constraint firstItem="jHm-dQ-yxg" firstAttribute="leading" secondItem="HLQ-m9-78F" secondAttribute="leading" constant="12" id="EFD-Yi-q9b"/>
-                <constraint firstItem="EUo-1b-VQe" firstAttribute="trailing" secondItem="iN0-l3-epB" secondAttribute="trailing" priority="250" constant="-14" id="Gin-mg-ylf"/>
                 <constraint firstItem="Fle-ET-bnW" firstAttribute="bottom" secondItem="eki-qS-IGB" secondAttribute="bottom" id="HwX-bO-MnW"/>
                 <constraint firstItem="eki-qS-IGB" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="8" id="IZx-jY-Fec"/>
                 <constraint firstItem="W2g-Ht-hY3" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="OqT-qa-XFw"/>
@@ -176,14 +154,12 @@
                 <constraint firstItem="ydv-Kv-9qv" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="YL9-xQ-wJB"/>
                 <constraint firstItem="OEt-3Q-8ri" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="eq2-Nh-tjE"/>
                 <constraint firstItem="eki-qS-IGB" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="12" id="fTX-vW-38x"/>
-                <constraint firstItem="EUo-1b-VQe" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="jHm-dQ-yxg" secondAttribute="trailing" constant="8" id="gsO-ph-O7d"/>
                 <constraint firstItem="8Sm-pj-7B1" firstAttribute="bottom" secondItem="OEt-3Q-8ri" secondAttribute="bottom" constant="-25" id="iDP-4u-O7T"/>
                 <constraint firstAttribute="trailing" secondItem="Fle-ET-bnW" secondAttribute="trailing" constant="16" id="kz9-Gy-UCb"/>
                 <constraint firstItem="Fle-ET-bnW" firstAttribute="height" secondItem="eki-qS-IGB" secondAttribute="height" id="n6u-9H-J8B"/>
                 <constraint firstItem="W2g-Ht-hY3" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="nHh-K1-jH2"/>
                 <constraint firstAttribute="bottom" secondItem="OEt-3Q-8ri" secondAttribute="bottom" id="qUC-5Y-BgY"/>
                 <constraint firstItem="DT6-XG-kaD" firstAttribute="height" secondItem="oQQ-DA-UJ9" secondAttribute="height" id="qYJ-pT-6yJ"/>
-                <constraint firstItem="EUo-1b-VQe" firstAttribute="centerY" secondItem="rTM-5K-tvz" secondAttribute="centerY" id="wEm-ht-3fR"/>
                 <constraint firstItem="eki-qS-IGB" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="ydv-Kv-9qv" secondAttribute="leading" constant="-80" id="yRo-9y-aW9"/>
                 <constraint firstItem="8Sm-pj-7B1" firstAttribute="leading" secondItem="HLQ-m9-78F" secondAttribute="leading" constant="12" id="zDf-pg-gkh"/>
             </constraints>

--- a/Source/Classes/View/CardView/Front/SmallFrontView.swift
+++ b/Source/Classes/View/CardView/Front/SmallFrontView.swift
@@ -7,7 +7,6 @@ public class SmallFrontView: CardView {
     @IBOutlet weak var cardBalanceContainer: CardBalance!
     
     // Constraints
-    @IBOutlet weak var safeZoneWidthConstraint: NSLayoutConstraint!
     @IBOutlet weak var paymentMethodImageWidthConstraint: NSLayoutConstraint!
     
     override func setupUI(_ cardUI: CardUI) {
@@ -39,12 +38,10 @@ public class SmallFrontView: CardView {
             customView.pinEdges(to: safeZone)
             
             safeZone.isHidden = false
-            safeZoneWidthConstraint.isActive = true
         }
     }
     
     func clearSafeZoneConstraints() {
-        safeZoneWidthConstraint.isActive = false
         
         // Make SafeZone hidden
         safeZone.isHidden = true

--- a/Source/Classes/View/CardView/Front/SmallFrontView.swift
+++ b/Source/Classes/View/CardView/Front/SmallFrontView.swift
@@ -1,50 +1,19 @@
-//
-//  SmallFrontView.swift
-//  MLCardDrawer
-//
-//  Created by Jonathan Scaramal on 30/06/2021.
-//
-
 import UIKit
 
 public class SmallFrontView: CardView {
-    @IBOutlet weak var expirationDate: CardLabel!
-    @IBOutlet weak var name: CardLabel!
     @IBOutlet weak var paymentMethodImage: UIImageView!
     @IBOutlet weak var bankImage: UIImageView!
-    @IBOutlet weak var number: CardLabel!
-    @IBOutlet weak var securityCodeCircle: CircleView!
-    
     @IBOutlet weak var safeZone: UIView!
+    @IBOutlet weak var cardBalanceContainer: CardBalance!
     
     // Constraints
-    @IBOutlet weak var numberToNameLeadingConstraint: NSLayoutConstraint!
-    var numberToNameLeadingProgConstraint : NSLayoutConstraint?
-    
-    @IBOutlet weak var nameToNumberTopConstraint: NSLayoutConstraint!
-    var nameToNumberTopProgConstraint : NSLayoutConstraint?
-    
-    @IBOutlet weak var nameLeadingConstraint: NSLayoutConstraint!
-    
-    @IBOutlet weak var numberTrailingConstraint: NSLayoutConstraint!
-    
-    @IBOutlet weak var numberLeadingConstraint: NSLayoutConstraint!
-    
-    var numberWidthAnchorProgConstraint : NSLayoutConstraint?
-    
-    @IBOutlet weak var nameBottomToSuperviewConstraint: NSLayoutConstraint!
-    
     @IBOutlet weak var safeZoneWidthConstraint: NSLayoutConstraint!
-    
     @IBOutlet weak var paymentMethodImageWidthConstraint: NSLayoutConstraint!
     
-    @IBOutlet weak var cardBalanceContainer: CardBalance!
-
     override func setupUI(_ cardUI: CardUI) {
         super.setupUI(cardUI)
         layer.cornerRadius = CardCornerRadiusManager.getCornerRadius(from: .large)
         
-        setupSecurityCode(cardUI)
         if cardUI.set(logo:) != nil {
             setupCardLogo(in: paymentMethodImage)
         }
@@ -52,65 +21,18 @@ public class SmallFrontView: CardView {
             setupBankImage(in: bankImage)
         }
         setupRemoteOrLocalImages(cardUI)
-        
-        setupFormatters(cardUI)
-        setupCardElements(cardUI)
-        
+                
         cardBackground = cardUI.cardBackgroundColor
         setupCustomOverlayImage(cardUI)
         
-        modifyCardPattern()
-        
         layoutIfNeeded()
     }
-    
-    private func setupFormatters(_ cardUI: CardUI) {
-        securityCode.formatter = Mask(pattern: [cardUI.securityCodePattern])
-        name.formatter = Mask(placeholder: cardUI.placeholderName)
-        number.formatter = Mask(pattern: cardUI.cardPattern, digits: model?.lastDigits)
-        expirationDate.formatter = Mask(placeholder: cardUI.placeholderExpiration)
-    }
-    
-    private func setupCardElements(_ cardUI: CardUI) {
-        let input = [model?.name, model?.expiration, model?.securityCode]
-        [name, expirationDate, securityCode].enumerated().forEach({
-            $0.element?.setup(input[$0.offset], FontFactory.font(cardUI), customLabelFontName: customLabelFontName)
-        })
 
-        number.setup(model?.number, FontFactory.font(cardUI, shadow: true), customLabelFontName: customLabelFontName)
-    }
-    
-    private func setupSecurityCode(_ cardUI: CardUI) {
-        securityCodeCircle.alpha = 0
-        securityCode.textColor = cardUI.cardFontColor
-        securityCode.isHidden = true
-    }
+    override func addObservers() {}
 
-    override func addObservers() {
-        addObserver(name, forKeyPath: #keyPath(model.name), options: .new, context: nil)
-        addObserver(number, forKeyPath: #keyPath(model.number), options: .new, context: nil)
-        addObserver(expirationDate, forKeyPath: #keyPath(model.expiration), options: .new, context: nil)
-        addObserver(securityCode, forKeyPath: #keyPath(model.securityCode), options: .new, context: nil)
-    }
-
-    deinit {
-        removeObserver(name, forKeyPath: #keyPath(model.name))
-        removeObserver(number, forKeyPath: #keyPath(model.number))
-        removeObserver(expirationDate, forKeyPath: #keyPath(model.expiration))
-        removeObserver(securityCode, forKeyPath: #keyPath(model.securityCode))
-    }
+    deinit {}
     
     func setSafeZoneConstraints () {
-        name.isHidden = true
-        
-        numberTrailingConstraint.isActive = false
-        
-        numberLeadingConstraint.isActive = true
-        
-        number.textAlignment = .left
-        
-        // Make SafeZone visible and add customView
-        
         if let customView = customView {
             safeZone.addSubview(customView)
             
@@ -121,83 +43,8 @@ public class SmallFrontView: CardView {
         }
     }
     
-    func modifyCardPattern() {
-        // Number width change
-        
-        if let cardUI = cardUI, cardUI.cardPattern.count > 0 {
-            
-            number.adjustsFontSizeToFitWidth = false
-            number.lineBreakMode = .byClipping
-            
-            number.font = number.font.withSize(16)
-            
-            number.textAlignment = .right
-            
-            var modifiedCardPattern : [Int], modifiedNumber : String, charCount : Int
-            
-            if cardUI.cardPattern.count > 2 || (cardUI.cardPattern.count == 2 && cardUI.cardPattern.reduce(0,+) > 12) {
-                
-                let font = number.font
-                // If card pattern is still bigger than two it will be modified
-                // If the last group is bigger than 6 chars use this one only, if not use last two groups
-                let offset = cardUI.cardPattern[cardUI.cardPattern.count - 1] > 6 ? 1 : 2
-                
-                // Get only the last two groups of numbers
-                let range = cardUI.cardPattern.index(cardUI.cardPattern.endIndex, offsetBy: -1 * offset) ..< cardUI.cardPattern.endIndex
-                
-                modifiedCardPattern = Array(cardUI.cardPattern[range])
-                
-                cardUI.cardPattern = modifiedCardPattern
-                
-                modifiedNumber = model?.number ?? ""
-                
-                charCount = modifiedCardPattern.reduce(0, +)
-                
-                // Get only the last parts of cardNumber
-                if let cardNumber = model?.number, cardNumber.count > charCount {
-                    let numberRange = cardNumber.index(cardNumber.endIndex, offsetBy: charCount * -1) ..< cardNumber.endIndex
-                    modifiedNumber = String(cardNumber[numberRange])
-                }
-                
-            } else {
-                modifiedNumber = model?.number ?? ""
-                
-                modifiedCardPattern = cardUI.cardPattern
-                
-                charCount = modifiedCardPattern.reduce(0, +)
-            }
-            
-            let slices = min(max(modifiedCardPattern.count - 1, 0), 1)
-            
-            let totalChars = slices + charCount
-            
-            let kerning = number.formatter.attributes[.kern] as? Double ?? 0.0
-            
-            let width = CGFloat(totalChars) * number.font.size(" ", kerning: kerning).width
-            
-            numberWidthAnchorProgConstraint = number.widthAnchor.constraint(equalToConstant: CGFloat(width))
-            
-            numberWidthAnchorProgConstraint?.isActive = true
-            
-            number.layoutIfNeeded()
-            
-            number.formatter = Mask(pattern: modifiedCardPattern, digits: modifiedNumber)
-            
-            model?.number = modifiedNumber
-        }
-        
-    }
-    
     func clearSafeZoneConstraints() {
         safeZoneWidthConstraint.isActive = false
-        
-        name.isHidden = false
-        
-        numberTrailingConstraint.isActive = true
-        
-        numberLeadingConstraint.isActive = false
-        
-        number.textAlignment = .right
         
         // Make SafeZone hidden
         safeZone.isHidden = true
@@ -206,7 +53,6 @@ public class SmallFrontView: CardView {
             customView.removeFromSuperview()
             self.customView = nil
         }
-        
     }
     
     override func addCardBalance(_ model: CardBalanceModel, _ showBalance: Bool, _ delegate: CardBalanceDelegate) {
@@ -223,16 +69,14 @@ extension SmallFrontView {
         if !(cardUI is CustomCardDrawerUI) {
             Animator.overlay(on: self,
                              cardUI: cardUI,
-                             views: [bankImage, expirationDate, paymentMethodImage, name, number, securityCode],
+                             views: [bankImage, paymentMethodImage],
                              complete: {[weak self] in
                                 self?.setupUI(cardUI)
             })
         }
     }
 
-    public override func showSecurityCode() {
-        securityCodeCircle.alpha = 1
-    }
+    public override func showSecurityCode() {}
 
     private func setupRemoteOrLocalImages(_ cardUI: CardUI) {
         setBankImage(cardUI)

--- a/Source/Classes/View/CardView/Front/SmallFrontView.xib
+++ b/Source/Classes/View/CardView/Front/SmallFrontView.xib
@@ -17,7 +17,6 @@
                 <outlet property="paymentMethodImage" destination="hVB-2M-iYt" id="Tr2-It-Ho8"/>
                 <outlet property="paymentMethodImageWidthConstraint" destination="hD1-07-weO" id="eYN-ug-Jtw"/>
                 <outlet property="safeZone" destination="L4o-xR-CfT" id="l7R-Vk-asA"/>
-                <outlet property="safeZoneWidthConstraint" destination="QwL-eM-RI0" id="J72-Va-RDY"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>

--- a/Source/Classes/View/CardView/Front/SmallFrontView.xib
+++ b/Source/Classes/View/CardView/Front/SmallFrontView.xib
@@ -85,7 +85,7 @@
                     </constraints>
                 </view>
                 <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L4o-xR-CfT" userLabel="SafeZone">
-                    <rect key="frame" x="256" y="47" width="0.0" height="111"/>
+                    <rect key="frame" x="0.0" y="47" width="256" height="111"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EBB-Aq-UH8" customClass="CardBalance" customModule="MLCardDrawer">
@@ -101,7 +101,7 @@
                 <constraint firstItem="OEt-3Q-8ri" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="0si-Gj-xOe"/>
                 <constraint firstItem="HLQ-m9-78F" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="1Vb-Vh-OMD"/>
                 <constraint firstItem="eki-qS-IGB" firstAttribute="trailing" secondItem="N94-Fg-ynK" secondAttribute="leading" id="3Bk-h4-rS6"/>
-                <constraint firstItem="L4o-xR-CfT" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="trailing" id="3tQ-5Q-dQp"/>
+                <constraint firstItem="L4o-xR-CfT" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="3tQ-5Q-dQp"/>
                 <constraint firstAttribute="trailing" secondItem="W2g-Ht-hY3" secondAttribute="trailing" id="42g-gv-JyA"/>
                 <constraint firstAttribute="bottom" secondItem="HLQ-m9-78F" secondAttribute="bottom" id="8Hh-Yk-8Vu"/>
                 <constraint firstItem="iqG-Eo-eGS" firstAttribute="height" secondItem="hVB-2M-iYt" secondAttribute="height" id="9Yf-sg-dM3"/>

--- a/Source/Classes/View/CardView/Front/SmallFrontView.xib
+++ b/Source/Classes/View/CardView/Front/SmallFrontView.xib
@@ -85,7 +85,7 @@
                     </constraints>
                 </view>
                 <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L4o-xR-CfT" userLabel="SafeZone">
-                    <rect key="frame" x="0.0" y="47" width="256" height="111"/>
+                    <rect key="frame" x="128" y="47" width="128" height="111"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EBB-Aq-UH8" customClass="CardBalance" customModule="MLCardDrawer">
@@ -101,7 +101,6 @@
                 <constraint firstItem="OEt-3Q-8ri" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="0si-Gj-xOe"/>
                 <constraint firstItem="HLQ-m9-78F" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="1Vb-Vh-OMD"/>
                 <constraint firstItem="eki-qS-IGB" firstAttribute="trailing" secondItem="N94-Fg-ynK" secondAttribute="leading" id="3Bk-h4-rS6"/>
-                <constraint firstItem="L4o-xR-CfT" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="3tQ-5Q-dQp"/>
                 <constraint firstAttribute="trailing" secondItem="W2g-Ht-hY3" secondAttribute="trailing" id="42g-gv-JyA"/>
                 <constraint firstAttribute="bottom" secondItem="HLQ-m9-78F" secondAttribute="bottom" id="8Hh-Yk-8Vu"/>
                 <constraint firstItem="iqG-Eo-eGS" firstAttribute="height" secondItem="hVB-2M-iYt" secondAttribute="height" id="9Yf-sg-dM3"/>
@@ -115,7 +114,6 @@
                 <constraint firstItem="W2g-Ht-hY3" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="OqT-qa-XFw"/>
                 <constraint firstAttribute="trailing" secondItem="OEt-3Q-8ri" secondAttribute="trailing" id="Qc7-uP-wIt"/>
                 <constraint firstItem="N94-Fg-ynK" firstAttribute="centerX" secondItem="HLQ-m9-78F" secondAttribute="centerX" id="QpT-U2-dW4"/>
-                <constraint firstItem="L4o-xR-CfT" firstAttribute="width" secondItem="iN0-l3-epB" secondAttribute="width" multiplier="0.5" id="QwL-eM-RI0"/>
                 <constraint firstAttribute="trailing" secondItem="HLQ-m9-78F" secondAttribute="trailing" id="RP9-3G-Afk"/>
                 <constraint firstItem="HLQ-m9-78F" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="Roz-63-Y1h"/>
                 <constraint firstItem="Fle-ET-bnW" firstAttribute="trailing" secondItem="iN0-l3-epB" secondAttribute="trailing" constant="-12" id="ZmV-6D-57z"/>
@@ -127,17 +125,13 @@
                 <constraint firstItem="EBB-Aq-UH8" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="12" id="p3L-OB-ghg"/>
                 <constraint firstAttribute="bottom" secondItem="OEt-3Q-8ri" secondAttribute="bottom" id="qUC-5Y-BgY"/>
                 <constraint firstItem="eki-qS-IGB" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="12" id="qwy-YV-L6X"/>
+                <constraint firstItem="L4o-xR-CfT" firstAttribute="width" secondItem="iN0-l3-epB" secondAttribute="width" multiplier="0.5" id="rGR-kx-1uA"/>
                 <constraint firstAttribute="trailing" secondItem="EBB-Aq-UH8" secondAttribute="trailing" constant="16" id="xqX-Ig-sAR"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <variation key="default">
-                <mask key="constraints">
-                    <exclude reference="QwL-eM-RI0"/>
-                </mask>
-            </variation>
             <variation key="heightClass=regular">
                 <mask key="constraints">
                     <exclude reference="lzF-pf-ote"/>

--- a/Source/Classes/View/CardView/Front/SmallFrontView.xib
+++ b/Source/Classes/View/CardView/Front/SmallFrontView.xib
@@ -86,7 +86,7 @@
                     </constraints>
                 </view>
                 <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L4o-xR-CfT" userLabel="SafeZone">
-                    <rect key="frame" x="256" y="82" width="0.0" height="76"/>
+                    <rect key="frame" x="256" y="47" width="0.0" height="111"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EBB-Aq-UH8" customClass="CardBalance" customModule="MLCardDrawer">
@@ -112,7 +112,7 @@
                 <constraint firstItem="eki-qS-IGB" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="4" id="IZx-jY-Fec"/>
                 <constraint firstItem="N94-Fg-ynK" firstAttribute="centerY" secondItem="eki-qS-IGB" secondAttribute="centerY" id="JAx-5z-yUI"/>
                 <constraint firstAttribute="bottom" secondItem="L4o-xR-CfT" secondAttribute="bottom" id="JLJ-Ig-NDT"/>
-                <constraint firstAttribute="trailing" secondItem="L4o-xR-CfT" secondAttribute="trailing" id="OZa-Qs-T7s"/>
+                <constraint firstItem="L4o-xR-CfT" firstAttribute="trailing" secondItem="EBB-Aq-UH8" secondAttribute="trailing" constant="16" id="OZa-Qs-T7s"/>
                 <constraint firstItem="W2g-Ht-hY3" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="OqT-qa-XFw"/>
                 <constraint firstAttribute="trailing" secondItem="OEt-3Q-8ri" secondAttribute="trailing" id="Qc7-uP-wIt"/>
                 <constraint firstItem="N94-Fg-ynK" firstAttribute="centerX" secondItem="HLQ-m9-78F" secondAttribute="centerX" id="QpT-U2-dW4"/>
@@ -122,7 +122,7 @@
                 <constraint firstItem="Fle-ET-bnW" firstAttribute="trailing" secondItem="iN0-l3-epB" secondAttribute="trailing" constant="-12" id="ZmV-6D-57z"/>
                 <constraint firstItem="OEt-3Q-8ri" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="eq2-Nh-tjE"/>
                 <constraint firstItem="Fle-ET-bnW" firstAttribute="height" secondItem="eki-qS-IGB" secondAttribute="height" id="l4O-bB-U3b"/>
-                <constraint firstItem="L4o-xR-CfT" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="82" id="lIc-Tz-Wo8"/>
+                <constraint firstItem="L4o-xR-CfT" firstAttribute="top" secondItem="EBB-Aq-UH8" secondAttribute="bottom" id="lIc-Tz-Wo8"/>
                 <constraint firstItem="hVB-2M-iYt" firstAttribute="height" secondItem="iN0-l3-epB" secondAttribute="height" multiplier="0.19" id="lzF-pf-ote"/>
                 <constraint firstItem="W2g-Ht-hY3" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="nHh-K1-jH2"/>
                 <constraint firstItem="EBB-Aq-UH8" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="12" id="p3L-OB-ghg"/>

--- a/Source/Classes/View/CardView/Front/SmallFrontView.xib
+++ b/Source/Classes/View/CardView/Front/SmallFrontView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -12,23 +12,12 @@
                 <outlet property="animation" destination="OEt-3Q-8ri" id="0bW-HL-KCE"/>
                 <outlet property="bankImage" destination="iqG-Eo-eGS" id="OQn-yr-FpB"/>
                 <outlet property="cardBalanceContainer" destination="EBB-Aq-UH8" id="Did-el-Ax9"/>
-                <outlet property="expirationDate" destination="AMu-xJ-OI6" id="uGb-Mm-U1i"/>
                 <outlet property="gradient" destination="W2g-Ht-hY3" id="gsv-Yn-Xxg"/>
-                <outlet property="name" destination="ZMN-U6-Lcy" id="YHC-Uc-QhK"/>
-                <outlet property="nameBottomToSuperviewConstraint" destination="Zqi-vG-kju" id="scP-g1-TgR"/>
-                <outlet property="nameLeadingConstraint" destination="47K-ZK-WHj" id="vgY-kj-uiS"/>
-                <outlet property="nameToNumberTopConstraint" destination="uAh-2S-u7H" id="3yg-Lu-kAi"/>
-                <outlet property="number" destination="EUo-1b-VQe" id="db1-YE-CVB"/>
-                <outlet property="numberLeadingConstraint" destination="qgN-p0-2Qw" id="0RB-1o-SF0"/>
-                <outlet property="numberToNameLeadingConstraint" destination="gPR-jP-sT0" id="8mx-sw-cSb"/>
-                <outlet property="numberTrailingConstraint" destination="7Fn-mR-gxB" id="sNk-Hl-Krn"/>
                 <outlet property="overlayImage" destination="HLQ-m9-78F" id="0tL-aV-K2z"/>
                 <outlet property="paymentMethodImage" destination="hVB-2M-iYt" id="Tr2-It-Ho8"/>
                 <outlet property="paymentMethodImageWidthConstraint" destination="hD1-07-weO" id="eYN-ug-Jtw"/>
                 <outlet property="safeZone" destination="L4o-xR-CfT" id="l7R-Vk-asA"/>
                 <outlet property="safeZoneWidthConstraint" destination="QwL-eM-RI0" id="J72-Va-RDY"/>
-                <outlet property="securityCode" destination="K3c-vy-wcQ" id="ghT-Qi-ZGO"/>
-                <outlet property="securityCodeCircle" destination="89T-PX-cWX" id="Edb-BS-E6z"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -88,54 +77,6 @@
                         <constraint firstAttribute="trailing" secondItem="iqG-Eo-eGS" secondAttribute="trailing" id="PP4-An-lQe"/>
                     </constraints>
                 </view>
-                <view alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="89T-PX-cWX" userLabel="circleFronSecurityCodeView" customClass="CircleView" customModule="MLCardDrawer">
-                    <rect key="frame" x="203" y="46" width="39" height="39"/>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="39" id="35R-WB-d8w"/>
-                        <constraint firstAttribute="width" constant="39" id="fQx-hB-TZV"/>
-                    </constraints>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
-                            <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        </userDefinedRuntimeAttribute>
-                        <userDefinedRuntimeAttribute type="color" keyPath="strokeColor">
-                            <color key="value" red="1" green="0.27816225080000001" blue="0.2427567534" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                        </userDefinedRuntimeAttribute>
-                        <userDefinedRuntimeAttribute type="number" keyPath="lineWidth">
-                            <real key="value" value="3"/>
-                        </userDefinedRuntimeAttribute>
-                    </userDefinedRuntimeAttributes>
-                </view>
-                <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="***" textAlignment="center" lineBreakMode="tailTruncation" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="K3c-vy-wcQ" userLabel="FrontSecurityCodeLabel" customClass="CardLabel" customModule="MLCardDrawer">
-                    <rect key="frame" x="215" y="58.5" width="17" height="14"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="right" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="**** **** **** ****" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="13" translatesAutoresizingMaskIntoConstraints="NO" id="EUo-1b-VQe" customClass="CardLabel" customModule="MLCardDrawer">
-                    <rect key="frame" x="129" y="82" width="115" height="18"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="18" id="cXL-fC-pUa"/>
-                    </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" text="NOMBRE Y APELLIDO" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZMN-U6-Lcy" customClass="CardLabel" customModule="MLCardDrawer">
-                    <rect key="frame" x="12" y="82" width="109" height="18"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MM/AA" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AMu-xJ-OI6" customClass="CardLabel" customModule="MLCardDrawer">
-                    <rect key="frame" x="179" y="82.5" width="53" height="17"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="53" id="6HL-Ki-gNc"/>
-                    </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="N94-Fg-ynK" userLabel="LimitView">
                     <rect key="frame" x="120" y="19" width="16" height="10"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -161,15 +102,11 @@
                 <constraint firstItem="OEt-3Q-8ri" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="0si-Gj-xOe"/>
                 <constraint firstItem="HLQ-m9-78F" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="1Vb-Vh-OMD"/>
                 <constraint firstItem="eki-qS-IGB" firstAttribute="trailing" secondItem="N94-Fg-ynK" secondAttribute="leading" id="3Bk-h4-rS6"/>
-                <constraint firstItem="L4o-xR-CfT" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="EUo-1b-VQe" secondAttribute="trailing" constant="12" id="3tQ-5Q-dQp"/>
+                <constraint firstItem="L4o-xR-CfT" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="trailing" id="3tQ-5Q-dQp"/>
                 <constraint firstAttribute="trailing" secondItem="W2g-Ht-hY3" secondAttribute="trailing" id="42g-gv-JyA"/>
-                <constraint firstItem="ZMN-U6-Lcy" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="12" id="47K-ZK-WHj"/>
-                <constraint firstItem="EUo-1b-VQe" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" constant="12" id="5aG-Iu-7JU"/>
-                <constraint firstAttribute="trailing" secondItem="EUo-1b-VQe" secondAttribute="trailing" constant="12" id="7Fn-mR-gxB"/>
                 <constraint firstAttribute="bottom" secondItem="HLQ-m9-78F" secondAttribute="bottom" id="8Hh-Yk-8Vu"/>
                 <constraint firstItem="iqG-Eo-eGS" firstAttribute="height" secondItem="hVB-2M-iYt" secondAttribute="height" id="9Yf-sg-dM3"/>
                 <constraint firstItem="Fle-ET-bnW" firstAttribute="centerY" secondItem="eki-qS-IGB" secondAttribute="centerY" id="ABo-lq-EY8"/>
-                <constraint firstItem="AMu-xJ-OI6" firstAttribute="height" secondItem="ZMN-U6-Lcy" secondAttribute="height" multiplier="0.944444" id="BYS-Z7-qkh"/>
                 <constraint firstAttribute="bottom" secondItem="W2g-Ht-hY3" secondAttribute="bottom" id="DWY-GP-FQC"/>
                 <constraint firstItem="Fle-ET-bnW" firstAttribute="leading" secondItem="N94-Fg-ynK" secondAttribute="trailing" id="He0-Y4-rhP"/>
                 <constraint firstItem="eki-qS-IGB" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="4" id="IZx-jY-Fec"/>
@@ -182,26 +119,15 @@
                 <constraint firstItem="L4o-xR-CfT" firstAttribute="width" secondItem="iN0-l3-epB" secondAttribute="width" multiplier="0.5" id="QwL-eM-RI0"/>
                 <constraint firstAttribute="trailing" secondItem="HLQ-m9-78F" secondAttribute="trailing" id="RP9-3G-Afk"/>
                 <constraint firstItem="HLQ-m9-78F" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="Roz-63-Y1h"/>
-                <constraint firstItem="K3c-vy-wcQ" firstAttribute="trailing" secondItem="AMu-xJ-OI6" secondAttribute="trailing" id="V0X-Zg-lw3"/>
-                <constraint firstItem="AMu-xJ-OI6" firstAttribute="centerY" secondItem="ZMN-U6-Lcy" secondAttribute="centerY" id="YcG-Cp-uXh"/>
-                <constraint firstItem="Fle-ET-bnW" firstAttribute="trailing" secondItem="EUo-1b-VQe" secondAttribute="trailing" id="ZmV-6D-57z"/>
-                <constraint firstAttribute="bottom" secondItem="ZMN-U6-Lcy" secondAttribute="bottom" constant="36" id="Zqi-vG-kju"/>
-                <constraint firstItem="EUo-1b-VQe" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="adj-bl-Bef"/>
+                <constraint firstItem="Fle-ET-bnW" firstAttribute="trailing" secondItem="iN0-l3-epB" secondAttribute="trailing" constant="-12" id="ZmV-6D-57z"/>
                 <constraint firstItem="OEt-3Q-8ri" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="eq2-Nh-tjE"/>
-                <constraint firstItem="EUo-1b-VQe" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="ZMN-U6-Lcy" secondAttribute="trailing" constant="8" id="gPR-jP-sT0"/>
-                <constraint firstItem="K3c-vy-wcQ" firstAttribute="centerY" secondItem="89T-PX-cWX" secondAttribute="centerY" id="goL-C4-4Ge"/>
                 <constraint firstItem="Fle-ET-bnW" firstAttribute="height" secondItem="eki-qS-IGB" secondAttribute="height" id="l4O-bB-U3b"/>
-                <constraint firstItem="L4o-xR-CfT" firstAttribute="top" secondItem="EUo-1b-VQe" secondAttribute="top" id="lIc-Tz-Wo8"/>
+                <constraint firstItem="L4o-xR-CfT" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="82" id="lIc-Tz-Wo8"/>
                 <constraint firstItem="hVB-2M-iYt" firstAttribute="height" secondItem="iN0-l3-epB" secondAttribute="height" multiplier="0.19" id="lzF-pf-ote"/>
-                <constraint firstAttribute="trailing" secondItem="AMu-xJ-OI6" secondAttribute="trailing" constant="24" id="mQC-Xx-HlH"/>
                 <constraint firstItem="W2g-Ht-hY3" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="nHh-K1-jH2"/>
                 <constraint firstItem="EBB-Aq-UH8" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="12" id="p3L-OB-ghg"/>
                 <constraint firstAttribute="bottom" secondItem="OEt-3Q-8ri" secondAttribute="bottom" id="qUC-5Y-BgY"/>
-                <constraint firstItem="EUo-1b-VQe" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="qgN-p0-2Qw"/>
-                <constraint firstItem="eki-qS-IGB" firstAttribute="leading" secondItem="ZMN-U6-Lcy" secondAttribute="leading" id="qwy-YV-L6X"/>
-                <constraint firstItem="ZMN-U6-Lcy" firstAttribute="top" secondItem="EUo-1b-VQe" secondAttribute="top" id="uAh-2S-u7H"/>
-                <constraint firstItem="89T-PX-cWX" firstAttribute="centerX" secondItem="K3c-vy-wcQ" secondAttribute="centerX" constant="-1" id="w6D-0s-Beo"/>
-                <constraint firstItem="EUo-1b-VQe" firstAttribute="top" secondItem="89T-PX-cWX" secondAttribute="bottom" constant="-3" id="weF-sf-C3X"/>
+                <constraint firstItem="eki-qS-IGB" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="12" id="qwy-YV-L6X"/>
                 <constraint firstAttribute="trailing" secondItem="EBB-Aq-UH8" secondAttribute="trailing" constant="16" id="xqX-Ig-sAR"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
@@ -210,9 +136,6 @@
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <variation key="default">
                 <mask key="constraints">
-                    <exclude reference="Zqi-vG-kju"/>
-                    <exclude reference="adj-bl-Bef"/>
-                    <exclude reference="qgN-p0-2Qw"/>
                     <exclude reference="QwL-eM-RI0"/>
                 </mask>
             </variation>


### PR DESCRIPTION
We are deleting number, name, expiration date and CVV (in small sizes) in the cards front layout, to prepare for the new visual styles. 

- Large (No CVV on front): 

| Before | After |
|:-:|:-:|
|![oldlarge](https://user-images.githubusercontent.com/61248081/183461026-dcef1e2e-c958-4615-b406-b7dfb11568c5.png)|  ![newlargenologo](https://user-images.githubusercontent.com/61248081/183461258-f979de90-56ce-45a3-b5db-3874c4187356.png)|

- Large (CVV on front): 

| Before | After |
|:-:|:-:|
|![oldlargelogo](https://user-images.githubusercontent.com/61248081/183461398-d11c01d0-5ac9-4a20-9be5-245a7aad6825.png)|  ![newlargelogo](https://user-images.githubusercontent.com/61248081/183461546-dfded0ca-ba1f-4a9b-9bc2-9e2e1fa90e56.png)|

- Medium

| Before | After |
|:-:|:-:|
|![oldmedium](https://user-images.githubusercontent.com/61248081/183461912-17c6450a-1e7c-41fd-a0b4-e07c999d1234.png)|  ![newmedium](https://user-images.githubusercontent.com/61248081/183461919-e1b4297e-caf0-4498-b65c-07976c3db43a.png)|

- Small

| Before | After |
|:-:|:-:|
|![oldsmall](https://user-images.githubusercontent.com/61248081/183462031-a6816b19-b578-4849-b3fb-60fad742967a.png)|  ![newsmall](https://user-images.githubusercontent.com/61248081/183462038-f15b7485-fd70-414e-bf44-e08f34bbd33c.png)|

- Combo large (issuer and bank logos will change placement so disregard differences in that).

| Before | After |
|:-:|:-:|
|![oldswitchbig](https://user-images.githubusercontent.com/61248081/183462770-14885446-c866-488d-87da-72c34718590d.png)|  ![newswitchbig](https://user-images.githubusercontent.com/61248081/183462776-50d723bf-6637-4d89-a35a-5ecea047f607.png)|


- Combo small

| Before | After |
|:-:|:-:|
|![oldswitchsmall](https://user-images.githubusercontent.com/61248081/183462796-dfb40246-c53b-4234-84b4-69615247e4fd.png)|  ![newswitchsmall](https://user-images.githubusercontent.com/61248081/183462804-31805a98-e1e9-441a-b5b6-0ca9b1582859.png)|





