### PR TITLE
(Changed)[CCAP-75] Remove available balance label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Unreleased]
+- hides the available balance label when it's not sent this info
+
 ## [Release (1.11.2)](https://github.com/mercadolibre/meli-card-drawer-ios/releases/tag/1.11.2)
 ## fix
 - changed combo switch redesign

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
-## [Unreleased]
-- hides the available balance label when it's not sent this info
-
 ## [Release (1.11.2)](https://github.com/mercadolibre/meli-card-drawer-ios/releases/tag/1.11.2)
 ## fix
 - changed combo switch redesign

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Unreleased]
+- Remove the available balance label when this info is not sent
+
 ## [Release (1.11.2)](https://github.com/mercadolibre/meli-card-drawer-ios/releases/tag/1.11.2)
 ## fix
 - changed combo switch redesign

--- a/Source/Classes/Models/CardBalanceModel.swift
+++ b/Source/Classes/Models/CardBalanceModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public struct CardBalanceModel: Codable {
-    let title: Text
+    let title: Text?
     let balance: Text
     let hiddenBalance: Text
     

--- a/Source/Classes/View/CardBalance/CardBalance.swift
+++ b/Source/Classes/View/CardBalance/CardBalance.swift
@@ -81,17 +81,11 @@ public class CardBalance: UIView {
             return
         }
         
-        if model.title != nil {
-            guard let title = model.title else { return }
+        if let title = model.title {
             balanceTitle.font = UIFont.systemFont(ofSize: titleFontSize, weight: .regular)
             balanceTitle.text = title.message
             setupLabelColors(balanceTitle, field: title)
-        } else {
-            balanceTitle.text = ""
         }
-        
-        
-        
         balanceLabel.font = UIFont.systemFont(ofSize: balanceFontSize, weight: .semibold)
         
         eyeImage = UIImageView()

--- a/Source/Classes/View/CardBalance/CardBalance.swift
+++ b/Source/Classes/View/CardBalance/CardBalance.swift
@@ -81,8 +81,16 @@ public class CardBalance: UIView {
             return
         }
         
-        balanceTitle.font = UIFont.systemFont(ofSize: titleFontSize, weight: .regular)
-        balanceTitle.text = model.title.message
+        if model.title != nil {
+            guard let title = model.title else { return }
+            balanceTitle.font = UIFont.systemFont(ofSize: titleFontSize, weight: .regular)
+            balanceTitle.text = title.message
+            setupLabelColors(balanceTitle, field: title)
+        } else {
+            balanceTitle.text = ""
+        }
+        
+        
         
         balanceLabel.font = UIFont.systemFont(ofSize: balanceFontSize, weight: .semibold)
         
@@ -96,8 +104,6 @@ public class CardBalance: UIView {
         balanceLabel.sizeToFit()
         balanceTitle.sizeToFit()
         eyeImage.sizeToFit()
-        
-        setupLabelColors(balanceTitle, field: model.title)
 
         self.addSubview(balanceTitle)
         self.addSubview(balanceLabel)


### PR DESCRIPTION
## What have changed ?
Remove the available balance label when it's not sent this info

## How to test:
Using a test credential with account money

## Screenshots for the change:
![Captura de tela 04 10 2022 às 16 00 42 PM](https://user-images.githubusercontent.com/107044799/193910033-926ce110-73c6-48d8-b6cf-f985c9324df9.png)
![Captura de tela 04 10 2022 às 16 00 55 PM](https://user-images.githubusercontent.com/107044799/193910044-9bfaedae-e994-494a-9d26-d988b77396a3.png)
