### PR TITLE
(Changed) [PXN-5161] - Adapting PANView for receiving an issuer image in split cases

### DIFF
--- a/Source/Classes/Protocols/CardUI.swift
+++ b/Source/Classes/Protocols/CardUI.swift
@@ -41,16 +41,19 @@ import UIKit
     public var backgroundColor: String?
     public var textColor: String?
     public var weight: String?
+    public var issuerImageUrl: String?
     
     public init(
         message: String?,
         backgroundColor: String?,
         textColor: String?,
-        weight: String?
+        weight: String?,
+        issuerImageUrl: String?
     ) {
         self.message = message
         self.backgroundColor = backgroundColor
         self.textColor = textColor
         self.weight = weight
+        self.issuerImageUrl = issuerImageUrl
     }
 }

--- a/Source/Classes/Utils/UIImage+Gray.swift
+++ b/Source/Classes/Utils/UIImage+Gray.swift
@@ -45,7 +45,7 @@ internal extension UIImage {
         return nil
     }
     
-    class func resize(image: UIImage, targetSize: CGSize) -> UIImage {
+    class func resize(image: UIImage, targetSize: CGSize) -> UIImage? {
         let size = image.size
         
         let widthRatio  = targetSize.width  / image.size.width
@@ -65,7 +65,7 @@ internal extension UIImage {
         let newImage = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
         
-        return newImage!
+        return newImage
     }
     
     class func scale(image: UIImage, by scale: CGFloat) -> UIImage? {

--- a/Source/Classes/View/PAN/PANView.swift
+++ b/Source/Classes/View/PAN/PANView.swift
@@ -1,6 +1,32 @@
 import UIKit
 
 class PANView: UIView {
+    //MARK: - Subviews
+    
+    private lazy var containerStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 4.0
+        stackView.distribution = .fill
+        return stackView
+    }()
+    
+    private lazy var PANIconImageContainer: UIImageView = {
+        let container = UIImageView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.contentMode = .scaleAspectFit
+        container.clipsToBounds = true
+        container.sizeToFit()
+        return container
+    }()
+    
+    //MARK: - Properties
+    
+    var cardUI: CardUI?
+    var PANLabel: UILabel!
+    private var PANContainer: UIView!
+    //MARK: - Enums
     
     enum PANLabelUI {
         static let labelPlaceHolder = "•••• ••••"
@@ -21,10 +47,13 @@ class PANView: UIView {
         static let containerDisabledColor: UIColor = .fromHex("#A0A0A0")
     }
     
-    var PANLabel: UILabel!
-    var PANContainer: UIView!
-    var cardUI: CardUI?
-
+    enum PANIconContainerUI {
+        static let leftPadding: CGFloat = 8.0
+        static let rightPadding: CGFloat = -4.0
+        static let containerHeight: CGFloat = 15.0
+    }
+    //MARK: - Init
+    
     public init() {
         super.init(frame: CGRect.zero)
     }
@@ -32,19 +61,11 @@ class PANView: UIView {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
-    
-    public func render() {
-        setupComponents()
-        setupConstraints()
-    }
-    
-    private func setupComponents() {
-        setupLabel()
-        setupContainer()
-    }
+    //MARK: - UI
     
     private func setupLabel() {
         PANLabel = UILabel()
+        PANLabel.translatesAutoresizingMaskIntoConstraints = false
         PANLabel.font = .proximaNovaSemibold(size: PANLabelUI.labelFontSize)
         PANLabel.backgroundColor = PANLabelUI.labelBackgroundColor
         PANLabel.textColor = PANLabelUI.labelTextColor
@@ -57,31 +78,45 @@ class PANView: UIView {
     
     private func setupContainer() {
         PANContainer = UIView()
+        PANContainer.translatesAutoresizingMaskIntoConstraints = false
         PANContainer.backgroundColor = PANContainerUI.containerBackgroundColor
         PANContainer.layer.cornerRadius = PANContainerUI.containerCornerRadius
         PANContainer.clipsToBounds = true
         PANContainer.sizeToFit()
     }
     
+    public func render() {
+        setupComponents()
+        setupConstraints()
+    }
+    
+    private func setupComponents() {
+        setupLabel()
+        setupContainer()
+    }
+    
     private func setupConstraints() {
-        self.addSubview(PANContainer)
-        PANContainer.addSubview(PANLabel)
         
-        PANLabel.translatesAutoresizingMaskIntoConstraints = false
-        PANContainer.translatesAutoresizingMaskIntoConstraints = false
+        self.addSubview(PANContainer)
+        PANContainer.addSubview(containerStackView)
         
         NSLayoutConstraint.activate([
+            
             PANContainer.topAnchor.constraint(equalTo: self.topAnchor),
             PANContainer.bottomAnchor.constraint(equalTo: self.bottomAnchor),
             PANContainer.rightAnchor.constraint(equalTo: self.rightAnchor),
             PANContainer.leftAnchor.constraint(equalTo: self.leftAnchor),
-            PANLabel.topAnchor.constraint(equalTo: PANContainer.topAnchor, constant: PANLabelUI.topPadding),
-            PANLabel.bottomAnchor.constraint(equalTo: PANContainer.bottomAnchor, constant: PANLabelUI.bottomPadding),
-            PANLabel.rightAnchor.constraint(equalTo: PANContainer.rightAnchor, constant: PANLabelUI.rightPadding),
-            PANLabel.leftAnchor.constraint(equalTo: PANContainer.leftAnchor, constant: PANLabelUI.leftPadding)
+            
+            containerStackView.topAnchor.constraint(equalTo: self.topAnchor, constant: PANLabelUI.topPadding),
+            containerStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: PANLabelUI.bottomPadding),
+            containerStackView.rightAnchor.constraint(equalTo: self.rightAnchor, constant: PANLabelUI.rightPadding),
+            containerStackView.leftAnchor.constraint(equalTo: self.leftAnchor, constant: PANLabelUI.leftPadding),
+            containerStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            containerStackView.heightAnchor.constraint(equalToConstant: PANIconContainerUI.containerHeight)
         ])
     }
 }
+//MARK: - Extensions
 
 extension PANView {
     
@@ -113,6 +148,12 @@ extension PANView {
             if let weight = panStyle?.weight {
                 setWeight(weight)
             }
+            
+            if let issuerImageUrl = panStyle?.issuerImageUrl {
+                setIssuerImage(issuerImageUrl)
+            } else {
+                containerStackView.addArrangedSubview(PANLabel)
+            }
         }
         
         if disabled {
@@ -136,40 +177,73 @@ extension PANView {
         PANLabel.font = weight.getFont(size: PANLabelUI.labelFontSize)
     }
     
+    private func setIssuerImage(_ issuerImage: String) {
+        PANIconImageContainer.image = nil
+        containerStackView.addArrangedSubview(self.PANIconImageContainer)
+        let imageURL = getIssuerImageUrl()
+        
+        if !imageURL.isEmpty {
+            PANIconImageContainer.getRemoteImage(imageUrl: imageURL) { remoteIssuerImage in
+                DispatchQueue.main.async { [weak self] in
+                    guard let self = self else { return }
+                    self.containerStackView.addArrangedSubview(self.PANLabel)
+                    self.setImage(remoteIssuerImage, inImageView: self.PANIconImageContainer, scaleHeight: true)
+                }
+            }
+        } else {
+            containerStackView.addArrangedSubview(PANLabel)
+            PANIconImageContainer.isHidden = true
+            PANIconImageContainer.removeFromSuperview()
+        }
+    }
+    
+    private func getIssuerImageUrl() -> String {
+        var issuerImageURL: String = ""
+        if let panStyle = cardUI?.panStyle {
+            issuerImageURL = panStyle?.issuerImageUrl ?? String()
+        }
+        return issuerImageURL
+    }
+    
+    private func setImage(_ tImage: UIImage, inImageView: UIImageView, scaleHeight: Bool = false) {
+        let aspectRatio = tImage.size.height/tImage.size.width
+        inImageView.image = scaleHeight ? UIImage.scale(image: tImage, by: (inImageView.bounds.size.height+max(-4,min(24*aspectRatio-15,0)))/tImage.size.height) : tImage
+    }
+    
     public func setDisabledStyle() {
         PANContainer.backgroundColor = PANContainerUI.containerDisabledColor
         PANLabel.textColor = PANLabelUI.labelDisabledTextColor
     }
+    //MARK: - Observer
     
-    //MARK: Observer
     override func observeValue(forKeyPath keyPath: String?,
                                of object: Any?,
                                change: [NSKeyValueChangeKey : Any]?,
                                context: UnsafeMutableRawPointer?) {
-
+        
         guard let change = change, let new = change[.newKey] else { return }
-
+        
         isHidden = false
         setNumber(PANLabelUI.labelPlaceHolder)
         var numberLength = cardUI?.cardPattern.reduce(0, +)
         var panStartingPoint = (numberLength ?? 0) - PANLabelUI.labelLength
-
+        
         if let changed = new as? String,
            let numberLength = numberLength,
            changed.count > panStartingPoint,
            panStartingPoint > 0 {
-
+            
             var numberOfCharactersChanged = changed.count
             var lastCharacterChanged = String(changed.suffix(1))
             var panSuffix = numberOfCharactersChanged - panStartingPoint
-
+            
             guard panSuffix >= 0 else { return }
             var panNumber = String(changed.suffix(panSuffix))
                 .replacingFirstOccurrence(of: "•", with: lastCharacterChanged)
                 .padding(toLength: PANLabelUI.labelLength, withPad: "•", startingAt: 0)
             
             if changed.count > 4 {
-            panNumber.insert(" ", at: changed.index(changed.startIndex, offsetBy: 4))
+                panNumber.insert(" ", at: changed.index(changed.startIndex, offsetBy: 4))
             }
             setNumber(panNumber)
         }


### PR DESCRIPTION
## What have changed?

We added a container in the PANView for the incoming issuer image from split cases. If the case is not split, we'll not show that container.

## How to test:

In the ExampleApp -> Helpers -> CardUIExamples, we implemented the optional var `panStyle` of the `CardUI` protocol, and tested the different scenarios.

- If the integrator set the URL for the issuerImage correctly.
- If the integrator set nil for the `issuerImageUrl`.
- If the integrator set a empty String.
- If the integrator send a bigger image than expected.


## Prints for layout changes:

- If the integrator set the URL for the `issuerImageUrl` correctly

![Simulator Screen Shot - iPhone 13 mini - 2022-10-17 at 14 31 52](https://user-images.githubusercontent.com/96147063/196244590-da38d0e7-e23c-43d9-bcbe-275037af0fa3.png)

![Captura de Pantalla 2022-10-17 a la(s) 14 06 03](https://user-images.githubusercontent.com/96147063/196244645-bc146ec3-7ec7-4c05-b1f5-c271d8b1ea55.png)

- If the integrator set nil for the `issuerImageUrl`

![Simulator Screen Shot - iPhone 13 mini - 2022-10-17 at 14 22 29](https://user-images.githubusercontent.com/96147063/196244729-a53b6dc8-b661-4306-892f-c3d5dd7c3bf6.png)

![Captura de Pantalla 2022-10-17 a la(s) 14 07 26](https://user-images.githubusercontent.com/96147063/196244806-290d2156-2abe-4350-aaec-a9de8be48dac.png)


- If the integrator set a empty String

![Simulator Screen Shot - iPhone 13 mini - 2022-10-17 at 14 22 29](https://user-images.githubusercontent.com/96147063/196244902-8db92268-6135-4f39-9704-0c29d2522ab8.png)

![Captura de Pantalla 2022-10-17 a la(s) 14 06 47](https://user-images.githubusercontent.com/96147063/196244934-02f4fe5f-941c-4f8a-85a8-ade424ff9109.png)


- If the integrator send a bigger image than expected (original dimensions of the testingImage: 2000x1553)

![Simulator Screen Shot - iPhone 13 mini - 2022-10-17 at 14 24 06](https://user-images.githubusercontent.com/96147063/196244990-963e2820-6031-4fe1-a5f6-0e17412aadfd.png)

![Captura de Pantalla 2022-10-17 a la(s) 14 04 48](https://user-images.githubusercontent.com/96147063/196245027-8dc2d60b-8224-4a31-812f-8686a143178c.png)

## Extras:




