### PR TITLE
Automatic Xcode Migration

### DIFF
--- a/MLCardDrawer.podspec
+++ b/MLCardDrawer.podspec
@@ -19,4 +19,7 @@ Pod::Spec.new do |s|
     default.source_files = ['Source/Classes/**/*.{h,m,swift}']
     default.resource_bundles = { 'MLCardDrawerResources' => ['Source/Assets/*.xcassets', 'Source/Classes/**/*.xib'] }
   end
+  
+  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  
 end


### PR DESCRIPTION
<h1>Migración Xcode 14 & iOS 16</h1>Desde el squad de Platform Updates de Arquitectura Mobile, tenemos el compromiso de velar por mantener el stack tecnológico actualizado. <br /><br />Este Pull Request es parte de la migración al nuevo Xcode 14 e iOS 16 y elimina una configuración de arquitectura para los simuladores de Xcode, que era necesaria para Xcode 12 y actual, pero no es necesaria y provoca un error para Xcode 14. <br /><br /><img src='https://user-images.githubusercontent.com/84388621/187287873-d06dad97-9c71-4c29-90ba-3896dc3190aa.png' /> <br /><br />Por favor haga el merge del PR se pasan los pasos del CI. También compartimos la <a href='https://sites.google.com/mercadolibre.com/mobile/gu%C3%ADas-y-problemas/gu%C3%ADas-de-migraci%C3%B3n/migraci%C3%B3n-xcode-14'>Wiki</a> con informaciones de la migración para el nuevo Xcode 14. <br /><br />Si tienes algún problema, busca nuestro squad de <a href='https://sites.google.com/mercadolibre.com/mobile/team/qui%C3%A9nes-somos#h.34n3nvj337r3'>Plataform Updates</a> o a través de nuestro canal de slack <a href='https://meli.slack.com/archives/C03UYBY6FKR'>#help-ios-v16.</a><br /><br />Saludos!